### PR TITLE
INTERLOK-2759 Add support for rows-affected-metadata-key

### DIFF
--- a/src/test/java/com/adaptris/csv/jdbc/TestJdbcBatchInsertCSV.java
+++ b/src/test/java/com/adaptris/csv/jdbc/TestJdbcBatchInsertCSV.java
@@ -1,5 +1,8 @@
 package com.adaptris.csv.jdbc;
 
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
@@ -12,11 +15,24 @@ public class TestJdbcBatchInsertCSV extends JdbcCSVInsertCase {
     super(arg0);
   }
 
+  public void testAccumulate() throws Exception {
+    int[] rc = {1, 2, Statement.EXECUTE_FAILED};
+    try {
+      BatchInsertCSV.accumulate(rc);
+    } catch (SQLException expected) {
+
+    }
+    int[] rc2 = {1, 2, Statement.SUCCESS_NO_INFO};
+    assertEquals(3, BatchInsertCSV.accumulate(rc2));
+  }
+
   public void testService() throws Exception {
     createDatabase();
-    BatchInsertCSV service = configureForTests(createService());
+    BatchInsertCSV service = configureForTests(createService()).withRowsAffectedMetadataKey("rowsAffected");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_CONTENT);
     execute(service, msg);
+    assertTrue(msg.headersContainsKey("rowsAffected"));
+    assertEquals("3", msg.getMetadataValue("rowsAffected"));
     doAssert(3);
   }
 
@@ -47,6 +63,7 @@ public class TestJdbcBatchInsertCSV extends JdbcCSVInsertCase {
     doAssert(3);
   }
 
+  @Override
   protected BatchInsertCSV createService() {
     return new BatchInsertCSV();
   }

--- a/src/test/java/com/adaptris/csv/jdbc/TestJdbcUpsertCSV.java
+++ b/src/test/java/com/adaptris/csv/jdbc/TestJdbcUpsertCSV.java
@@ -24,10 +24,11 @@ public class TestJdbcUpsertCSV extends JdbcCSVInsertCase {
 
   public void testService_Insert() throws Exception {
     createDatabase();
-    JdbcUpsertCSV service = configureForTests(createService());
-    service.setIdField(ID_ELEMENT_VALUE);
+    JdbcUpsertCSV service = configureForTests(createService()).withId(ID_ELEMENT_VALUE).withRowsAffectedMetadataKey("rowsAffected");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_CONTENT);
     execute(service, msg);
+    assertTrue(msg.headersContainsKey("rowsAffected"));
+    assertEquals("3", msg.getMetadataValue("rowsAffected"));
     doAssert(3);
   }
 
@@ -61,6 +62,7 @@ public class TestJdbcUpsertCSV extends JdbcCSVInsertCase {
     return configureForExamples(createService()).withId("id").withTable("myTable");
   }
 
+  @Override
   protected JdbcUpsertCSV createService() {
     return new JdbcUpsertCSV();
   }


### PR DESCRIPTION
- Add support for the rows-affected-metadata-key in CSV insert/upsert
- Refactor the executeBatch method for coverage.