### PR TITLE
INTERLOK-3322 switch to super csv

### DIFF
--- a/src/main/java/com/adaptris/core/transform/csv/BasicFormatBuilder.java
+++ b/src/main/java/com/adaptris/core/transform/csv/BasicFormatBuilder.java
@@ -1,33 +1,34 @@
 package com.adaptris.core.transform.csv;
 
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.csv.CSVFormat;
-
 import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Implementation of {@link FormatBuilder} that maps the standard commons-csv formats.
- * 
+ *
  * <p>
- * Basic parsing options are supported : {@link BasicFormatBuilder.Style#DEFAULT DEFAULT}, {@link BasicFormatBuilder.Style#EXCEL
- * EXCEL}, {@link BasicFormatBuilder.Style#RFC4180 RFC4180}, {@link BasicFormatBuilder.Style#MYSQL MYSQL} and
- * {@link BasicFormatBuilder.Style#TAB_DELIMITED TAB DELIMITED} which correspond to the base formats defined by {@link CSVFormat}.
+ * Basic parsing options are supported : {@link BasicFormatBuilder.Style#DEFAULT DEFAULT},
+ * {@link BasicFormatBuilder.Style#EXCEL EXCEL}, {@link BasicFormatBuilder.Style#RFC4180 RFC4180},
+ * {@link BasicFormatBuilder.Style#MYSQL MYSQL} and {@link BasicFormatBuilder.Style#TAB_DELIMITED
+ * TAB DELIMITED} which correspond to the base formats defined by {@link CSVFormat}.
  * </p>
- * 
- * 
+ *
+ *
  * @config csv-basic-format
- * @author lchan
- * 
+ * @deprecated since 3.11.0 : switch to using net.supercsv based implementations instead
  */
 @XStreamAlias("csv-basic-format")
+@Deprecated
+@Removal(version = "4.0.0", message = "Switch to using net.supercsv based implementations instead")
 public class BasicFormatBuilder implements FormatBuilder {
 
   /**
    * enum representing the standard supported CSV Formats.
-   * 
+   *
    * @see CSVFormat
    */
   public enum Style {
@@ -66,7 +67,7 @@ public class BasicFormatBuilder implements FormatBuilder {
     },
     /**
      * Corresponds to {@link CSVFormat#MYSQL}.
-     * 
+     *
      * <p>
      * Default MySQL format used by the <tt>SELECT INTO OUTFILE</tt> and <tt>LOAD DATA INFILE</tt> operations.
      * </p>
@@ -130,7 +131,7 @@ public class BasicFormatBuilder implements FormatBuilder {
   }
 
   public void setStyle(Style csvFormat) {
-    this.style = Args.notNull(csvFormat, "style");
+    style = Args.notNull(csvFormat, "style");
   }
 
   @Override

--- a/src/main/java/com/adaptris/core/transform/csv/CsvToXmlServiceImpl.java
+++ b/src/main/java/com/adaptris/core/transform/csv/CsvToXmlServiceImpl.java
@@ -1,16 +1,14 @@
 package com.adaptris.core.transform.csv;
 
 import java.io.OutputStream;
-
 import javax.validation.constraints.NotNull;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.Args;
@@ -20,8 +18,12 @@ import com.adaptris.util.XmlUtils;
 
 /**
  * Base class for transforming CSV into XML.
- * 
+ *
+ * @deprecated since 3.11.0 : switch to using net.supercsv based implementations instead
+ *
  */
+@Deprecated
+@Removal(version = "4.0.0", message = "Switch to using net.supercsv based implementations instead")
 public abstract class CsvToXmlServiceImpl extends CsvXmlTransformImpl {
 
   @NotNull
@@ -54,7 +56,7 @@ public abstract class CsvToXmlServiceImpl extends CsvXmlTransformImpl {
   }
 
   public void setFormat(FormatBuilder csvFormat) {
-    this.format = Args.notNull(csvFormat, "format");
+    format = Args.notNull(csvFormat, "format");
   }
 
   public Boolean getStripIllegalXmlChars() {
@@ -67,11 +69,11 @@ public abstract class CsvToXmlServiceImpl extends CsvXmlTransformImpl {
    * The following regular expression is used to strip out all invalid XML 1.0 characters :
    * <code>"[^\u0009\r\n\u0020-\uD7FF\uE000-\uFFFD\ud800\udc00-\udbff\udfff]"</code>.
    * </p>
-   * 
+   *
    * @param s true to enable stripping, default is null (true)
    */
   public void setStripIllegalXmlChars(Boolean s) {
-    this.stripIllegalXmlChars = s;
+    stripIllegalXmlChars = s;
   }
 
   protected boolean stripIllegalXmlChars() {
@@ -91,7 +93,7 @@ public abstract class CsvToXmlServiceImpl extends CsvXmlTransformImpl {
 
   /**
    * Helper method to write the XML document to the AdaptrisMessage taking into account any encoding requirements.
-   * 
+   *
    * @param doc the XML document
    * @param msg the AdaptrisMessage
    * @throws Exception

--- a/src/main/java/com/adaptris/core/transform/csv/CsvXmlTransformImpl.java
+++ b/src/main/java/com/adaptris/core/transform/csv/CsvXmlTransformImpl.java
@@ -2,20 +2,22 @@ package com.adaptris.core.transform.csv;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import org.apache.commons.lang3.BooleanUtils;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceImp;
 
 /**
  * Base class for transforming CSV into XML.
- * 
+ *
+ * @deprecated since 3.11.0 : switch to using net.supercsv based implementations instead
  */
+@Deprecated
+@Removal(version = "4.0.0", message = "Switch to using net.supercsv based implementations instead")
 public abstract class CsvXmlTransformImpl extends ServiceImp {
 
   protected static final String CSV_RECORD_NAME = "record";
@@ -27,7 +29,7 @@ public abstract class CsvXmlTransformImpl extends ServiceImp {
   private String outputMessageEncoding = null;
   @InputFieldDefault(value = "false")
   private Boolean includeLineNumberAttribute = null;
-  
+
   public CsvXmlTransformImpl() {
   }
 
@@ -58,7 +60,7 @@ public abstract class CsvXmlTransformImpl extends ServiceImp {
    * <p>
    * As a result; the character encoding on the message is always set using {@link AdaptrisMessage#setCharEncoding(String)}.
    * </p>
-   * 
+   *
    * @param encoding the character
    */
   public void setOutputMessageEncoding(String encoding) {
@@ -75,7 +77,7 @@ public abstract class CsvXmlTransformImpl extends ServiceImp {
     }
     return encoding;
   }
-  
+
 
   public Boolean getIncludeLineNumberAttribute() {
     return includeLineNumberAttribute;
@@ -83,14 +85,14 @@ public abstract class CsvXmlTransformImpl extends ServiceImp {
 
   /**
    * Specify whether or not to include the line number as an attribute on each record.
-   * 
-   * 
+   *
+   *
    * @param b whether to include the line number attribute default null (false)
    */
   public void setIncludeLineNumberAttribute(Boolean b) {
-    this.includeLineNumberAttribute = b;
+    includeLineNumberAttribute = b;
   }
-  
+
   protected boolean includeLineNumberAttribute() {
     return BooleanUtils.toBooleanDefaultIfNull(getIncludeLineNumberAttribute(), false);
   }

--- a/src/main/java/com/adaptris/core/transform/csv/CustomFormatBuilder.java
+++ b/src/main/java/com/adaptris/core/transform/csv/CustomFormatBuilder.java
@@ -1,24 +1,24 @@
 package com.adaptris.core.transform.csv;
 
 import java.lang.reflect.Method;
-
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import com.adaptris.annotation.Removal;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Implementation of {@link FormatBuilder} that allows for custom csv formats.
- * 
- * 
- * 
+ *
+ *
+ *
  * @config csv-custom-format
- * @author lchan
- * 
+ * @deprecated since 3.11.0 : switch to using net.supercsv based implementations instead
  */
+@Deprecated
 @XStreamAlias("csv-custom-format")
+@Removal(version = "4.0.0", message = "Switch to using net.supercsv based implementations instead")
 public class CustomFormatBuilder implements FormatBuilder {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass());
@@ -32,11 +32,11 @@ public class CustomFormatBuilder implements FormatBuilder {
   private Boolean ignoreEmptyLines;
   private Boolean ignoreSurroundingSpaces;
   private String recordSeparator;
-  
+
   // These are to protect us mostly from API changes in the nightly build
   // We call the appropriate methods reflectively.
   private static final String[] COMMENT_MARKER_METHODS = {
-    "withCommentMarker", 
+    "withCommentMarker",
     "withCommentStart"
   };
 
@@ -69,40 +69,40 @@ public class CustomFormatBuilder implements FormatBuilder {
     COMMENT_MARKER {
       @Override
       public CSVFormat create(CustomFormatBuilder config, CSVFormat current) {
-        return configureCSV(current, COMMENT_MARKER_METHODS, Character.class, this.name(), config.getCommentStart());
+        return configureCSV(current, COMMENT_MARKER_METHODS, Character.class, name(), config.getCommentStart());
       }
     },
     ESCAPE_CHARACTER {
       @Override
       public CSVFormat create(CustomFormatBuilder config, CSVFormat current) {
-        return configureCSV(current, ESCAPE_CHAR_METHODS, Character.class, this.name(), config.getEscape());
+        return configureCSV(current, ESCAPE_CHAR_METHODS, Character.class, name(), config.getEscape());
       }
     },
     QUOTE_CHARACTER {
       @Override
       public CSVFormat create(CustomFormatBuilder config, CSVFormat current) {
-        return configureCSV(current, QUOTE_CHAR_METHODS, Character.class, this.name(), config.getQuoteChar());
+        return configureCSV(current, QUOTE_CHAR_METHODS, Character.class, name(), config.getQuoteChar());
       }
 
     },
     IGNORE_EMPTY_LINES {
       @Override
       public CSVFormat create(CustomFormatBuilder config, CSVFormat current) {
-        return configureCSV(current, IGNORE_EMPTY_LINES_METHODS, boolean.class, this.name(), config.ignoreEmptyLines());
+        return configureCSV(current, IGNORE_EMPTY_LINES_METHODS, boolean.class, name(), config.ignoreEmptyLines());
       }
 
     },
     IGNORE_SURROUNDING_SPACES {
       @Override
       public CSVFormat create(CustomFormatBuilder config, CSVFormat current) {
-        return configureCSV(current, IGNORE_SURROUNDING_LINES_METHODS, boolean.class, this.name(), config.ignoreSurroundingSpaces());
+        return configureCSV(current, IGNORE_SURROUNDING_LINES_METHODS, boolean.class, name(), config.ignoreSurroundingSpaces());
       }
 
     },
     RECORD_SEPARATOR {
       @Override
       public CSVFormat create(CustomFormatBuilder config, CSVFormat current) {
-        return configureCSV(current, RECORD_SEPARATOR_METHODS, String.class, this.name(), config.recordSeparator());
+        return configureCSV(current, RECORD_SEPARATOR_METHODS, String.class, name(), config.recordSeparator());
       }
 
     };
@@ -125,11 +125,11 @@ public class CustomFormatBuilder implements FormatBuilder {
 
   /**
    * Set the delimiter for the CSV file.
-   * 
+   *
    * @param d the delimiter; if not specified, defaults to ","
    */
   public void setDelimiter(Character d) {
-    this.delimiter = d;
+    delimiter = d;
   }
 
   Character delimiter() {
@@ -166,11 +166,11 @@ public class CustomFormatBuilder implements FormatBuilder {
 
   /**
    * Specify whether or not to ignore empty lines.
-   * 
+   *
    * @param b true or false, if not specified false.
    */
   public void setIgnoreEmptyLines(Boolean b) {
-    this.ignoreEmptyLines = b;
+    ignoreEmptyLines = b;
   }
 
   boolean ignoreEmptyLines() {
@@ -183,11 +183,11 @@ public class CustomFormatBuilder implements FormatBuilder {
 
   /**
    * Specify whether or not to ignore surrounding spaces.
-   * 
+   *
    * @param b true or false, if not specified false.
    */
   public void setIgnoreSurroundingSpaces(Boolean b) {
-    this.ignoreSurroundingSpaces = b;
+    ignoreSurroundingSpaces = b;
   }
 
   boolean ignoreSurroundingSpaces() {
@@ -200,11 +200,11 @@ public class CustomFormatBuilder implements FormatBuilder {
 
   /**
    * Set the record separactor
-   * 
+   *
    * @param sep the record separator; if not specified defaults to "\r\n"
    */
   public void setRecordSeparator(String sep) {
-    this.recordSeparator = sep;
+    recordSeparator = sep;
   }
 
   String recordSeparator() {

--- a/src/main/java/com/adaptris/core/transform/csv/FormatBuilder.java
+++ b/src/main/java/com/adaptris/core/transform/csv/FormatBuilder.java
@@ -1,18 +1,20 @@
 package com.adaptris.core.transform.csv;
 
 import org.apache.commons.csv.CSVFormat;
+import com.adaptris.annotation.Removal;
 
 /**
  * Builder for creating the required format for parsing the CSV file.
- * 
- * @author lchan
- * 
+ *
+ * @deprecated since 3.11.0 : switch to using net.supercsv based implementations instead
  */
+@Deprecated
+@Removal(version = "4.0.0", message = "Switch to using net.supercsv based implementations instead")
 public interface FormatBuilder {
 
   /**
    * Create the CSVFormat.
-   * 
+   *
    * @return the CSV Format.
    */
   CSVFormat createFormat();

--- a/src/main/java/com/adaptris/core/transform/csv/RawCsvToXmlTransformService.java
+++ b/src/main/java/com/adaptris/core/transform/csv/RawCsvToXmlTransformService.java
@@ -3,48 +3,50 @@ package com.adaptris.core.transform.csv;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Raw CSV to XML using {@link CSVParser}.
- * 
+ *
  * <p>
- * This transformation uses <a href="http://commons.apache.org/proper/commons-csv/">commons-csv</a> as the parsing engine for a CSV
- * file. Basic parsing options are supported : {@link BasicFormatBuilder.Style#DEFAULT DEFAULT},
- * {@link BasicFormatBuilder.Style#EXCEL EXCEL}, {@link BasicFormatBuilder.Style#RFC4180 RFC4180},
- * {@link BasicFormatBuilder.Style#MYSQL MYSQL} and {@link BasicFormatBuilder.Style#TAB_DELIMITED TAB DELIMITED} which correspond to
- * the base formats defined by {@link CSVFormat}. Custom CSV formats are provided via {@link CustomFormatBuilder}.
+ * This transformation uses <a href="http://commons.apache.org/proper/commons-csv/">commons-csv</a>
+ * as the parsing engine for a CSV file. Basic parsing options are supported :
+ * {@link BasicFormatBuilder.Style#DEFAULT DEFAULT}, {@link BasicFormatBuilder.Style#EXCEL EXCEL},
+ * {@link BasicFormatBuilder.Style#RFC4180 RFC4180}, {@link BasicFormatBuilder.Style#MYSQL MYSQL}
+ * and {@link BasicFormatBuilder.Style#TAB_DELIMITED TAB DELIMITED} which correspond to the base
+ * formats defined by {@link CSVFormat}. Custom CSV formats are provided via
+ * {@link CustomFormatBuilder}.
  * </p>
  * <p>
- * This service does not attempt to make parsing decisions, so CSV files that have differing number of columns on each line would be
- * perfectly acceptable.
+ * This service does not attempt to make parsing decisions, so CSV files that have differing number
+ * of columns on each line would be perfectly acceptable.
  * </p>
  * <p>
  * For example, given an input document :
- * 
+ *
  * <pre>
- * {@code 
+ * {@code
 HEADER,19052017
 PRODUCT-CODE,BARCODE,DP,PROMPRICE,DISCOUNT,INSTOCK,REPORT,REPORT-DATE,SOURCE
 XXXXXXXX,1234567890123,2.75,0.00,5.00,2,,,GSL
 TRAILER,4
    }
-   </pre> Then the output would be
- * 
+ * </pre>
+ *
+ * Then the output would be
+ *
  * <pre>
  * {@code
   <csv-xml>
@@ -79,21 +81,24 @@ TRAILER,4
       <csv-field-2>4</csv-field-2>
    </record>
   </csv-xml>
-} </pre>
+}
+ * </pre>
  * </p>
  * <p>
- * Because there is no verification that the CSV columns matchup; if the message type isn't a CSV (e.g. it's JSON or XML), then it
- * will still be marked up into XML, so take that into account when using this as part of a workflow. Behaviour with rogue messages
- * may not be as you expect.
+ * Because there is no verification that the CSV columns matchup; if the message type isn't a CSV
+ * (e.g. it's JSON or XML), then it will still be marked up into XML, so take that into account when
+ * using this as part of a workflow. Behaviour with rogue messages may not be as you expect.
  * </p>
- * 
+ *
  * @config raw-csv-to-xml-transform
- * 
+ * @deprecated since 3.11.0 : switch to using net.supercsv based implementations instead
  */
+@Deprecated
 @XStreamAlias("raw-csv-to-xml-transform")
 @AdapterComponent
 @ComponentProfile(summary = "Easily transform a document from CSV to XML", tag = "service,transform,csv,xml")
 @DisplayOrder(order = {"format", "outputMessageEncoding", "stripIllegalXmlChars"})
+@Removal(version = "4.0.0", message = "Switch to using net.supercsv based implementations instead")
 public class RawCsvToXmlTransformService extends CsvToXmlServiceImpl {
 
   public RawCsvToXmlTransformService() {
@@ -106,6 +111,7 @@ public class RawCsvToXmlTransformService extends CsvToXmlServiceImpl {
   }
 
 
+  @Override
   protected Document transform(AdaptrisMessage msg) throws ServiceException {
     Document doc = null;
     CSVFormat format = getFormat().createFormat();
@@ -115,7 +121,7 @@ public class RawCsvToXmlTransformService extends CsvToXmlServiceImpl {
       CSVParser parser = format.parse(in);
       Element root = doc.createElement(XML_ROOT_ELEMENT);
       doc.appendChild(root);
-      int recordCount = 1;      
+      int recordCount = 1;
       for (CSVRecord record : parser) {
         Element recordElement = addNewElement(doc, root, CSV_RECORD_NAME);
         if (includeLineNumberAttribute()) {
@@ -126,7 +132,7 @@ public class RawCsvToXmlTransformService extends CsvToXmlServiceImpl {
         for (Element field : csvFields) {
           recordElement.appendChild(field);
         }
-        recordCount++;        
+        recordCount++;
       }
     }
     catch (Exception e) {

--- a/src/main/java/com/adaptris/core/transform/csv/RawCsvToXmlTransformService.java
+++ b/src/main/java/com/adaptris/core/transform/csv/RawCsvToXmlTransformService.java
@@ -14,7 +14,9 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.LoggingHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -101,6 +103,7 @@ TRAILER,4
 @Removal(version = "4.0.0", message = "Switch to using net.supercsv based implementations instead")
 public class RawCsvToXmlTransformService extends CsvToXmlServiceImpl {
 
+  private transient boolean warningLogged;
   public RawCsvToXmlTransformService() {
     super();
   }
@@ -110,6 +113,13 @@ public class RawCsvToXmlTransformService extends CsvToXmlServiceImpl {
     setFormat(f);
   }
 
+  @Override
+  public void prepare() throws CoreException {
+    LoggingHelper.logDeprecation(warningLogged, () -> warningLogged = true,
+        this.getClass().getCanonicalName(),
+        com.adaptris.csv.transform.UncheckedCsvToXml.class.getCanonicalName());
+    super.prepare();
+  }
 
   @Override
   protected Document transform(AdaptrisMessage msg) throws ServiceException {
@@ -155,5 +165,6 @@ public class RawCsvToXmlTransformService extends CsvToXmlServiceImpl {
     }
     return result;
   }
+
 
 }

--- a/src/main/java/com/adaptris/core/transform/csv/SimpleCsvToXmlTransformService.java
+++ b/src/main/java/com/adaptris/core/transform/csv/SimpleCsvToXmlTransformService.java
@@ -3,20 +3,18 @@ package com.adaptris.core.transform.csv;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.lang3.BooleanUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.XmlHelper;
@@ -24,32 +22,39 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Simple CSV to XML using {@link CSVParser}.
- * 
+ *
  * <p>
- * This transformation uses <a href="http://commons.apache.org/proper/commons-csv/">commons-csv</a> as the parsing engine for a CSV
- * file. Basic parsing options are supported : {@link BasicFormatBuilder.Style#DEFAULT DEFAULT},
- * {@link BasicFormatBuilder.Style#EXCEL EXCEL}, {@link BasicFormatBuilder.Style#RFC4180 RFC4180},
- * {@link BasicFormatBuilder.Style#MYSQL MYSQL} and {@link BasicFormatBuilder.Style#TAB_DELIMITED TAB DELIMITED} which correspond to
- * the base formats defined by {@link CSVFormat}. Custom CSV formats are provided via {@link CustomFormatBuilder}. In the event that
- * you have more complex requirements then you should be looking to use the {@code FlatFileTransformService} instead.
+ * This transformation uses <a href="http://commons.apache.org/proper/commons-csv/">commons-csv</a>
+ * as the parsing engine for a CSV file. Basic parsing options are supported :
+ * {@link BasicFormatBuilder.Style#DEFAULT DEFAULT}, {@link BasicFormatBuilder.Style#EXCEL EXCEL},
+ * {@link BasicFormatBuilder.Style#RFC4180 RFC4180}, {@link BasicFormatBuilder.Style#MYSQL MYSQL}
+ * and {@link BasicFormatBuilder.Style#TAB_DELIMITED TAB DELIMITED} which correspond to the base
+ * formats defined by {@link CSVFormat}. Custom CSV formats are provided via
+ * {@link CustomFormatBuilder}. In the event that you have more complex requirements then you should
+ * be looking to use the {@code FlatFileTransformService} instead.
  * </p>
  * <p>
- * If {@link #setElementNamesFromFirstRecord(Boolean)} is true, then the first record is used to generate the element names;
- * otherwise names are auto-generated based on the count of fields in the first row. Results are undefined if subsequent record
- * contains more fields than the first record. If the first row contains a blank field then the <code>blank</code> is used as the
- * element name. Note that if your header rows contains characters that would not be allowed in an standard XML element name then it
- * will be replaced with an '_', so "Order Date" becomes "Order_Date".
+ * If {@link #setElementNamesFromFirstRecord(Boolean)} is true, then the first record is used to
+ * generate the element names; otherwise names are auto-generated based on the count of fields in
+ * the first row. Results are undefined if subsequent record contains more fields than the first
+ * record. If the first row contains a blank field then the <code>blank</code> is used as the
+ * element name. Note that if your header rows contains characters that would not be allowed in an
+ * standard XML element name then it will be replaced with an '_', so "Order Date" becomes
+ * "Order_Date".
  * </p>
  * <p>
  * For example, given an input document :
- * 
+ *
  * <pre>
  * <code>
 Event Name,Order Date,Ticket Type,Date Attending,Total Paid
 Glastonbury,"Sep 15, 2012",Free entry,"Jun 26, 2014 at 6:00 PM",0
 Reading Festival,"Sep 16, 2012",Free entry,"Aug 30, 2014 at 6:00 PM",0
- * </code> </pre> Then the output (without a header row, and with unique-record-names=true) would be
- * 
+ * </code>
+ * </pre>
+ *
+ * Then the output (without a header row, and with unique-record-names=true) would be
+ *
  * <pre>
  * <code>
  * &lt;csv-xml>
@@ -74,10 +79,11 @@ Reading Festival,"Sep 16, 2012",Free entry,"Aug 30, 2014 at 6:00 PM",0
  *     &lt;csv-field-4>Aug 30, 2014 at 6:00 PM&lt;/csv-field-4>
  *     &lt;csv-field-5>0&lt;/csv-field-5>
  *   &lt;/record-3>
- * </code> </pre>
- * 
+ * </code>
+ * </pre>
+ *
  * And with a header row specified (and unique-record-names = true):
- * 
+ *
  * <pre>
  * <code>
  * &lt;csv-xml>
@@ -95,15 +101,18 @@ Reading Festival,"Sep 16, 2012",Free entry,"Aug 30, 2014 at 6:00 PM",0
  *     &lt;Date_Attending>Aug 30, 2014 at 6:00 PM&lt;/Date_Attending>
  *     &lt;Total_Paid>0&lt;/Total_Paid>
  *   &lt;/record-2>
- * </code> </pre>
- * 
+ * </code>
+ * </pre>
+ *
  * @config simple-csv-to-xml-transform
- * 
+ * @deprecated since 3.11.0 : switch to using net.supercsv based implementations instead
  */
+@Deprecated
 @XStreamAlias("simple-csv-to-xml-transform")
 @AdapterComponent
 @ComponentProfile(summary = "Easily transform a document from CSV to XML", tag = "service,transform,csv,xml")
 @DisplayOrder(order = {"format", "outputMessageEncoding", "elementNamesFromFirstRecord", "uniqueRecordNames", "stripIllegalXmlChars"})
+@Removal(version = "4.0.0", message = "Switch to using net.supercsv based implementations instead")
 public class SimpleCsvToXmlTransformService extends CsvToXmlServiceImpl {
 
   @InputFieldDefault(value = "false")
@@ -121,6 +130,7 @@ public class SimpleCsvToXmlTransformService extends CsvToXmlServiceImpl {
   }
 
 
+  @Override
   protected Document transform(AdaptrisMessage msg) throws ServiceException {
     Document doc = null;
     CSVFormat format = getFormat().createFormat();
@@ -170,11 +180,11 @@ public class SimpleCsvToXmlTransformService extends CsvToXmlServiceImpl {
 
   /**
    * Specify if element names should be derived from the first record.
-   * 
+   *
    * @param b true to set the first record as the header.
    */
   public void setElementNamesFromFirstRecord(Boolean b) {
-    this.elementNamesFromFirstRecord = b;
+    elementNamesFromFirstRecord = b;
   }
 
   boolean elemNamesFirstRec() {
@@ -215,19 +225,19 @@ public class SimpleCsvToXmlTransformService extends CsvToXmlServiceImpl {
   public Boolean getUniqueRecordNames() {
     return uniqueRecordNames;
   }
-  
+
   /**
    * Specify whether or not to have unique element names for each record in the CSV file.
-   * 
+   *
    * <p>
    * If there are multiple records in then each record can have a unique element name; e.g <code>record-1, record-2, record-3</code>
    * and so on. If false, then they are all called <code>record</code> with an associated attribute that declares the line number.
    * </p>
-   * 
+   *
    * @param b true to generate a unique element name for each line in the CSV, default null (false)
    */
   public void setUniqueRecordNames(Boolean b) {
-    this.uniqueRecordNames = b;
+    uniqueRecordNames = b;
   }
 
   boolean uniqueRecords() {

--- a/src/main/java/com/adaptris/core/transform/csv/SimpleCsvToXmlTransformService.java
+++ b/src/main/java/com/adaptris/core/transform/csv/SimpleCsvToXmlTransformService.java
@@ -16,7 +16,9 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.core.util.XmlHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -120,6 +122,8 @@ public class SimpleCsvToXmlTransformService extends CsvToXmlServiceImpl {
   @InputFieldDefault(value = "false")
   private Boolean uniqueRecordNames = null;
 
+  private transient boolean warningLogged;
+
   public SimpleCsvToXmlTransformService() {
     super();
   }
@@ -129,6 +133,13 @@ public class SimpleCsvToXmlTransformService extends CsvToXmlServiceImpl {
     setFormat(f);
   }
 
+  @Override
+  public void prepare() throws CoreException {
+    LoggingHelper.logDeprecation(warningLogged, () -> warningLogged = true,
+        this.getClass().getCanonicalName(),
+        com.adaptris.csv.transform.CsvToXml.class.getCanonicalName());
+    super.prepare();
+  }
 
   @Override
   protected Document transform(AdaptrisMessage msg) throws ServiceException {

--- a/src/main/java/com/adaptris/core/transform/csv/StreamingCsvToXml.java
+++ b/src/main/java/com/adaptris/core/transform/csv/StreamingCsvToXml.java
@@ -1,208 +1,35 @@
 package com.adaptris.core.transform.csv;
 
-import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.Reader;
-import java.io.Writer;
-import java.util.Map;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import javax.xml.stream.XMLStreamWriter;
-
-import com.adaptris.annotation.AdapterComponent;
-import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.ServiceException;
-import com.adaptris.core.util.Args;
-import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LoggingHelper;
-import com.adaptris.core.util.XmlHelper;
-import com.adaptris.csv.BasicPreferenceBuilder;
-import com.adaptris.csv.OrderedCsvMapReader;
-import com.adaptris.csv.PreferenceBuilder;
-import com.adaptris.stax.DefaultWriterFactory;
-import com.adaptris.stax.StreamWriterFactory;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
 
 /**
  * CSV to XML using {@code net.sf.supercsv:super-csv} via {@link XMLStreamWriter}
- * 
- * <p>
- * This transformation uses {@code net.sf.supercsv:super-csv} as the parsing engine for a CSV file and uses {@link XMLStreamWriter}
- * via {@code com.adaptris:interlok-stax} to write each row as part of an XML document. It may have better performance
- * characteristics with large CSV files compared to {@link SimpleCsvToXmlTransformService}. It also reduces the number of
- * configuration options that are available.
- * <p>
- * Element names are always generated from the first line; so a header line is always assumed; Note that if your header rows
- * contains characters that would not be allowed in an standard XML element name then it will be replaced with an '_', so "Order
- * Date" becomes "Order_Date". Additionally illegal XML characters are always stripped (illegal characters would cause an exception
- * regardless in the {@link XMLStreamWriter}).
- * </p>
- * <p>
- * For example, given an input document :
- * 
- * <pre>
- * <code>
-Event Name,Order Date,Ticket Type,Date Attending,Total Paid
-Glastonbury,"Sep 15, 2012",Free entry,"Jun 26, 2014 at 6:00 PM",0
-Reading Festival,"Sep 16, 2012",Free entry,"Aug 30, 2014 at 6:00 PM",0
- * </code> </pre> Then the output (without a header row) would be
- * 
- * <pre>
- * <code>
- * &lt;csv-xml>
- *   &lt;record line="1">
- *     &lt;Event_Name>Glastonbury&lt;/Event_Name>
- *     &lt;Order_Date>Sep 15, 2012&lt;/Order_Date>
- *     &lt;Ticket_Type>Free entry&lt;/Ticket_Type>
- *     &lt;Date_Attending>Jun 26, 2014 at 6:00 PM&lt;/Date_Attending>
- *     &lt;Total_Paid>0&lt;/Total_Paid>
- *   &lt;/record>
- *   &lt;record line="2">
- *     &lt;Event_Name>Reading Festival&lt;/Event_Name>
- *     &lt;Order_Date>Sep 16, 2012&lt;/Order_Date>
- *     &lt;Ticket_Type>Free entry&lt;/Ticket_Type>
- *     &lt;Date_Attending>Aug 30, 2014 at 6:00 PM&lt;/Date_Attending>
- *     &lt;Total_Paid>0&lt;/Total_Paid>
- *   &lt;/record>
- * </code> </pre>
- * 
- * @config streaming-csv-to-xml-transform
- * 
+ * @deprecated since 3.11.0 : Use {@link com.adaptris.csv.transform.StreamingCsvToXml} instead.
  */
-@XStreamAlias("streaming-csv-to-xml-transform")
-@AdapterComponent
+@Deprecated
 @ComponentProfile(summary = "Transform CSV to XML using the XML streaming API (STaX).", tag = "service,transform,csv,xml", since = "3.6.6")
 @DisplayOrder(order = {"preferenceBuilder", "outputMessageEncoding", "streamWriterFactory"})
-public class StreamingCsvToXml extends CsvXmlTransformImpl {
+@Removal(version = "4.0.0", message = "Use com.adaptris.csv.transform.StreamingCsvToXml instead")
+@NoArgsConstructor
+public class StreamingCsvToXml extends com.adaptris.csv.transform.StreamingCsvToXml {
 
-  @NotNull
-  @AutoPopulated
-  @Valid
-  @InputFieldDefault(value = "csv-basic-preference-builder")
-  private PreferenceBuilder preferenceBuilder;
+  private transient boolean warningLogged;
 
-  @Valid
-  @AdvancedConfig
-  @InputFieldDefault(value = "stax-default-stream-writer")
-  private StreamWriterFactory streamWriter;
-
-  public StreamingCsvToXml() {
-    setPreferenceBuilder(new BasicPreferenceBuilder(BasicPreferenceBuilder.Style.STANDARD_PREFERENCE));
-  }
-
-  public StreamingCsvToXml(PreferenceBuilder prefs, StreamWriterFactory fact) {
-    this();
-    setPreferenceBuilder(prefs);
-    setStreamWriter(fact);
-  }
-
-
-  @Override
-  public void doService(AdaptrisMessage msg) throws ServiceException {
-    log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
-    StreamWriterFactory writerFactory = writerFactory();
-    XMLStreamWriter xmlWriter = null;
-    int count = 0;
-    long start = System.currentTimeMillis();
-    try {
-      String encoding = evaluateEncoding(msg);
-      try (Reader reader = new BufferedReader(msg.getReader());
-          OrderedCsvMapReader csvReader = new OrderedCsvMapReader(reader, getPreferenceBuilder().build());
-          Writer writer = new BufferedWriter(msg.getWriter(encoding))) {
-
-        xmlWriter = writerFactory.create(writer);
-        log.trace("Using {}", xmlWriter.getClass().getName());
-        xmlWriter.writeStartDocument(encoding, "1.0");
-        xmlWriter.writeStartElement(XML_ROOT_ELEMENT);
-        String[] hdrs = safeElementNames(csvReader.getHeader(true));
-        for (Map<String, String> row; (row = csvReader.read(hdrs)) != null;) {
-          xmlWriter.writeStartElement(CSV_RECORD_NAME);
-          count++;
-          if (includeLineNumberAttribute()) {
-            xmlWriter.writeAttribute("line", String.valueOf(count));
-          }
-          for (Map.Entry<String, String> entry : row.entrySet()) {
-            String elementData = XmlHelper.stripIllegalXmlCharacters(defaultIfEmpty(entry.getValue(), ""));
-            if (!isEmpty(elementData)) {
-              xmlWriter.writeStartElement(entry.getKey());
-              xmlWriter.writeCharacters(XmlHelper.stripIllegalXmlCharacters(entry.getValue()));
-              xmlWriter.writeEndElement();
-            }
-            else {
-              xmlWriter.writeEmptyElement(entry.getKey());
-            }
-          }
-          xmlWriter.writeEndElement();
-        }
-        xmlWriter.writeEndElement();
-        xmlWriter.writeEndDocument();
-      }
-      msg.setContentEncoding(encoding);
-    }
-    catch (Exception e) {
-      throw ExceptionHelper.wrapServiceException(e);
-    }
-    finally {
-      writerFactory.close(xmlWriter);
-    }
-    log.trace("Converted {} rows to XML in {}ms", count, System.currentTimeMillis() - start);
-  }
 
   @Override
   public void prepare() throws CoreException {
+    LoggingHelper.logDeprecation(warningLogged, () -> warningLogged = true,
+        this.getClass().getCanonicalName(),
+        com.adaptris.csv.transform.StreamingCsvToXml.class.getCanonicalName());
+    super.prepare();
   }
 
-  @Override
-  protected void initService() throws CoreException {
-  }
 
-  @Override
-  protected void closeService() {
-  }
-
-  public PreferenceBuilder getPreferenceBuilder() {
-    return preferenceBuilder;
-  }
-
-  public void setPreferenceBuilder(PreferenceBuilder b) {
-    this.preferenceBuilder = Args.notNull(b, "preferenceBuilder");
-  }
-
-  /**
-   * @return the streamWriterFactory
-   */
-  public StreamWriterFactory getStreamWriter() {
-    return streamWriter;
-  }
-
-  /**
-   * Set the stream writer factory to use.
-   * 
-   * @param factory the streamWriterFactory to set, default is {@link DefaultWriterFactory} if not specified.
-   */
-  public void setStreamWriter(StreamWriterFactory factory) {
-    this.streamWriter = factory;
-  }
-
-  StreamWriterFactory writerFactory() {
-    return getStreamWriter() != null ? getStreamWriter() : new DefaultWriterFactory();
-  }
-
-  private static String[] safeElementNames(String[] input) {
-    for (int i = 0; i < input.length; i++) {
-      input[i] = XmlHelper.safeElementName(input[i], "blank");
-    }
-    return input;
-  }
 
 }

--- a/src/main/java/com/adaptris/core/transform/csv/package-info.java
+++ b/src/main/java/com/adaptris/core/transform/csv/package-info.java
@@ -1,7 +1,9 @@
 /**
  * <p>
- * Implementation of the core {@link com.adaptris.core.Service} interface providing CSV to XML transformation functionality.
+ * Implementation of the core {@link com.adaptris.core.Service} interface providing CSV to XML
+ * transformation functionality.
  * </p>
- * <img alt="UML" src="package.svg"/>
+ * 
  */
+@Deprecated
 package com.adaptris.core.transform.csv;

--- a/src/main/java/com/adaptris/csv/OrderedCsvMapReader.java
+++ b/src/main/java/com/adaptris/csv/OrderedCsvMapReader.java
@@ -3,17 +3,16 @@ package com.adaptris.csv;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-
 import org.supercsv.io.CsvMapReader;
 import org.supercsv.prefs.CsvPreference;
 import org.supercsv.util.Util;
-
 import com.adaptris.core.util.Args;
 
 /**
  * Extends {@code CsvMapReader} but uses {@link LinkedHashMap} as the underlying map implementation for predictable iteration order.
- * 
+ *
  *
  */
 public class OrderedCsvMapReader extends CsvMapReader {
@@ -29,6 +28,18 @@ public class OrderedCsvMapReader extends CsvMapReader {
       final Map<String, String> destination = new LinkedHashMap<String, String>(nameMapping.length);
       Util.filterListToMap(destination, nameMapping, getColumns());
       return destination;
+    }
+    return null; // EOF
+  }
+
+  /**
+   * Read the next row without thinking about nameMappings
+   * 
+   * @return the next row of data.
+   */
+  public List<String> readNext() throws IOException {
+    if (readRow()) {
+      return getColumns();
     }
     return null; // EOF
   }

--- a/src/main/java/com/adaptris/csv/aggregator/CsvAggregator.java
+++ b/src/main/java/com/adaptris/csv/aggregator/CsvAggregator.java
@@ -15,19 +15,7 @@
  *******************************************************************************/
 package com.adaptris.csv.aggregator;
 
-import java.io.BufferedOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
-import com.adaptris.core.services.aggregator.MessageAggregatorImpl;
-import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -46,11 +34,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Aggregate messages into a CSV, optionally prefixing a header", since = "3.9.3.1",
     tag = "csv,aggregator")
 public class CsvAggregator extends CsvAggregating {
-
-  public CsvAggregator withHeader(String s) {
-    setHeader(s);
-    return this;
-  }
 
   @Override
   protected boolean forceColumns() {

--- a/src/main/java/com/adaptris/csv/aggregator/CsvValidatingAggregator.java
+++ b/src/main/java/com/adaptris/csv/aggregator/CsvValidatingAggregator.java
@@ -1,28 +1,13 @@
 package com.adaptris.csv.aggregator;
 
+import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
-import com.adaptris.core.services.aggregator.MessageAggregatorImpl;
-
-import java.util.Collection;
-import java.util.List;
-
-import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.csv.CSVRecord;
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Attempts to aggregate messages into a CSV file.
@@ -48,16 +33,10 @@ public class CsvValidatingAggregator extends CsvAggregating
   @AdvancedConfig
   @Getter
   @Setter
-  private Boolean forceColumns = Boolean.TRUE;
-
-  public CsvValidatingAggregator withHeader(String s) {
-    header = s;
-    return this;
-  }
+  private Boolean forceColumns;
 
   @Override
-  protected boolean forceColumns()
-  {
-    return ObjectUtils.defaultIfNull(forceColumns, true);
+  protected boolean forceColumns() {
+    return BooleanUtils.toBooleanDefaultIfNull(getForceColumns(), true);
   }
 }

--- a/src/main/java/com/adaptris/csv/aggregator/package-info.java
+++ b/src/main/java/com/adaptris/csv/aggregator/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * <p>
+ * Aggregating messages into a CSV file.
+ * </p>
+ */
+package com.adaptris.csv.aggregator;

--- a/src/main/java/com/adaptris/csv/jdbc/package-info.java
+++ b/src/main/java/com/adaptris/csv/jdbc/package-info.java
@@ -3,6 +3,5 @@
  * Provides CSV support for when interacting with databases via JDBC.
  * </p>
  * 
- * <img alt="UML" src="package.svg"/>
  */
 package com.adaptris.csv.jdbc;

--- a/src/main/java/com/adaptris/csv/package-info.java
+++ b/src/main/java/com/adaptris/csv/package-info.java
@@ -2,7 +2,5 @@
  * <p>
  * Supporting components for CSV handling
  * </p>
- * 
- * <img alt="UML" src="package.svg"/>
  */
 package com.adaptris.csv;

--- a/src/main/java/com/adaptris/csv/splitter/package-info.java
+++ b/src/main/java/com/adaptris/csv/splitter/package-info.java
@@ -2,7 +2,5 @@
  * <p>
  * Custom splitter implementations
  * </p>
- * 
- * <img alt="UML" src="package.svg"/>
  */
 package com.adaptris.csv.splitter;

--- a/src/main/java/com/adaptris/csv/transform/CsvToXml.java
+++ b/src/main/java/com/adaptris/csv/transform/CsvToXml.java
@@ -1,0 +1,203 @@
+package com.adaptris.csv.transform;
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.apache.commons.lang3.BooleanUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.csv.OrderedCsvMapReader;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * CSV to XML using {@code net.sf.supercsv:super-csv} replacing
+ * {@link com.adaptris.core.transform.csv.SimpleCsvToXmlTransformService}.
+ * <p>
+ * This transformation uses {@code net.sf.supercsv:super-csv} as the parsing engine for a CSV file
+ * to write each row as part of an XML document.
+ * <p>
+ * If {@link #setElementNamesFromFirstRecord(Boolean)} is true, then the first record is used to
+ * generate the element names; otherwise names are auto-generated based on the count of fields in
+ * the first row. Results are undefined if subsequent record contains more fields than the first
+ * record. If the first row contains a blank field then the <code>blank</code> is used as the
+ * element name. Note that if your header rows contains characters that would not be allowed in an
+ * standard XML element name then it will be replaced with an '_', so "Order Date" becomes
+ * "Order_Date".
+ * </p>
+ * <p>
+ * For example, given an input document :
+ *
+ * <pre>
+ * <code>
+Event Name,Order Date,Ticket Type,Date Attending,Total Paid
+Glastonbury,"Sep 15, 2012",Free entry,"Jun 26, 2014 at 6:00 PM",0
+Reading Festival,"Sep 16, 2012",Free entry,"Aug 30, 2014 at 6:00 PM",0
+ * </code>
+ * </pre>
+ *
+ * Then the output (without a header row, and with unique-record-names=true) would be
+ *
+ * <pre>
+ * <code>
+ * &lt;csv-xml>
+ *   &lt;record-1>
+ *     &lt;csv-field-1>Event Name&lt;/csv-field-1>
+ *     &lt;csv-field-2>Order Date&lt;/csv-field-2>
+ *     &lt;csv-field-3>Ticket Type&lt;/csv-field-3>
+ *     &lt;csv-field-4>Date Attending&lt;/csv-field-4>
+ *     &lt;csv-field-5>Total Paid&lt;/csv-field-5>
+ *   &lt;/record-1>
+ *   &lt;record-2>
+ *     &lt;csv-field-1>Glastonbury&lt;/csv-field-1>
+ *     &lt;csv-field-2>Sep 15, 2012&lt;/csv-field-2>
+ *     &lt;csv-field-3>Free entry&lt;/csv-field-3>
+ *     &lt;csv-field-4>Jun 26, 2014 at 6:00 PM&lt;/csv-field-4>
+ *     &lt;csv-field-5>0&lt;/csv-field-5>
+ *   &lt;/record-2>
+ *   &lt;record-3>
+ *     &lt;csv-field-1>Reading Festival&lt;/csv-field-1>
+ *     &lt;csv-field-2>Sep 16, 2012&lt;/csv-field-2>
+ *     &lt;csv-field-3>Free entry&lt;/csv-field-3>
+ *     &lt;csv-field-4>Aug 30, 2014 at 6:00 PM&lt;/csv-field-4>
+ *     &lt;csv-field-5>0&lt;/csv-field-5>
+ *   &lt;/record-3>
+ * </code>
+ * </pre>
+ *
+ * And with a header row specified (and unique-record-names = true):
+ *
+ * <pre>
+ * <code>
+ * &lt;csv-xml>
+ *   &lt;record-1>
+ *     &lt;Event_Name>Glastonbury&lt;/Event_Name>
+ *     &lt;Order_Date>Sep 15, 2012&lt;/Order_Date>
+ *     &lt;Ticket_Type>Free entry&lt;/Ticket_Type>
+ *     &lt;Date_Attending>Jun 26, 2014 at 6:00 PM&lt;/Date_Attending>
+ *     &lt;Total_Paid>0&lt;/Total_Paid>
+ *   &lt;/record-1>
+ *   &lt;record-2>
+ *     &lt;Event_Name>Reading Festival&lt;/Event_Name>
+ *     &lt;Order_Date>Sep 16, 2012&lt;/Order_Date>
+ *     &lt;Ticket_Type>Free entry&lt;/Ticket_Type>
+ *     &lt;Date_Attending>Aug 30, 2014 at 6:00 PM&lt;/Date_Attending>
+ *     &lt;Total_Paid>0&lt;/Total_Paid>
+ *   &lt;/record-2>
+ * </code>
+ * </pre>
+ *
+ * @config csv-to-xml-transform
+ */
+@XStreamAlias("csv-to-xml-transform")
+@AdapterComponent
+@ComponentProfile(summary = "Transform a document from CSV to XML",
+    tag = "service,transform,csv,xml", since = "3.11.0")
+@DisplayOrder(order = {"format", "outputMessageEncoding", "elementNamesFromFirstRecord", "uniqueRecordNames", "stripIllegalXmlChars"})
+@NoArgsConstructor
+public class CsvToXml extends CsvToXmlServiceImpl {
+
+  /**
+   * Specify if element names should be derived from the first record.
+   *
+   */
+  @InputFieldDefault(value = "false")
+  @Getter
+  @Setter
+  private Boolean elementNamesFromFirstRecord;
+  /**
+   * Specify whether or not to have unique element names for each record in the CSV file.
+   *
+   * <p>
+   * If there are multiple records in then each record can have a unique element name; e.g
+   * <code>record-1, record-2, record-3</code> and so on. If false, then they are all called
+   * <code>record</code> with an associated attribute that declares the line number.
+   * </p>
+   *
+   */
+  @InputFieldDefault(value = "false")
+  @Getter
+  @Setter
+  private Boolean uniqueRecordNames = null;
+
+  @Override
+  protected Document transform(AdaptrisMessage msg) throws ServiceException {
+    Document doc = null;
+    String encoding = evaluateEncoding(msg);
+
+    try (Reader in = msg.getReader();
+        OrderedCsvMapReader csvReader =
+            new OrderedCsvMapReader(in, buildPreferences());) {
+      doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+      int recordCount = 1;
+      boolean firstRecord = true;
+      List<String> elemNames = null;
+      Element root = doc.createElement(XML_ROOT_ELEMENT);
+      doc.appendChild(root);
+      for (List<String> record; (record = csvReader.readNext()) != null;) {
+        if (firstRecord) {
+          firstRecord = false;
+          if (elemNamesFirstRec()) {
+            elemNames = safeElementNames(record);
+            continue;
+          }
+          else {
+            elemNames = createElementNames(record.size());
+          }
+        }
+        String recordName = CSV_RECORD_NAME + ((uniqueRecords()) ? "-" + recordCount : "");
+        Element recordElement = addNewElement(doc, root, recordName);
+        if (includeLineNumberAttribute()) {
+          recordElement.setAttribute("line", String.valueOf(recordCount));
+        }
+        // Create the sub doc here.
+        List<Element> csvFields = createFields(doc, record, elemNames);
+        for (Element field : csvFields) {
+          recordElement.appendChild(field);
+        }
+        recordCount++;
+      }
+    }
+    catch (Exception e) {
+      throw new ServiceException("Failed to convert CSV to XML", e);
+    }
+    return doc;
+  }
+
+  private boolean elemNamesFirstRec() {
+    return BooleanUtils.toBooleanDefaultIfNull(getElementNamesFromFirstRecord(), false);
+  }
+
+
+  private static final List<String> createElementNames(int count) {
+    List<String> result = new ArrayList<>();
+    for (int i = 1; i <= count; i++) {
+      result.add(CSV_FIELD_NAME + "-" + i);
+    }
+    return safeElementNames(result);
+  }
+
+  private List<Element> createFields(Document doc, List<String> record, List<String> headerNames) {
+    List<Element> result = new ArrayList<>();
+    for (int i = 0; i < record.size(); i++) {
+      Element element = doc.createElement(headerNames.get(i));
+      element.appendChild(createTextNode(doc, record.get(i)));
+      result.add(element);
+    }
+    return result;
+  }
+
+  private boolean uniqueRecords() {
+    return BooleanUtils.toBooleanDefaultIfNull(getUniqueRecordNames(), false);
+  }
+
+}

--- a/src/main/java/com/adaptris/csv/transform/CsvToXmlServiceImpl.java
+++ b/src/main/java/com/adaptris/csv/transform/CsvToXmlServiceImpl.java
@@ -1,0 +1,106 @@
+package com.adaptris.csv.transform;
+
+import java.io.OutputStream;
+import javax.validation.Valid;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.supercsv.prefs.CsvPreference;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.XmlHelper;
+import com.adaptris.csv.BasicPreferenceBuilder;
+import com.adaptris.csv.BasicPreferenceBuilder.Style;
+import com.adaptris.csv.PreferenceBuilder;
+import com.adaptris.util.XmlUtils;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Base class for transforming CSV into XML.
+ *
+ */
+@NoArgsConstructor
+public abstract class CsvToXmlServiceImpl extends CsvXmlTransformImpl {
+
+  /**
+   * How to parse the CSV file.
+   *
+   */
+  @Valid
+  @Getter
+  @Setter
+  @InputFieldDefault(value = "csv-basic-preference-builder")
+  private PreferenceBuilder preferenceBuilder;
+  /**
+   * Specify whether or not to strip illegal XML characters from all the data before converting to
+   * XML.
+   * <p>
+   * The following regular expression is used to strip out all invalid XML 1.0 characters :
+   * <code>"[^\u0009\r\n\u0020-\uD7FF\uE000-\uFFFD\ud800\udc00-\udbff\udfff]"</code>.
+   * </p>
+   *
+   */
+  @Getter
+  @Setter
+  @InputFieldDefault(value = "true")
+  @AdvancedConfig
+  private Boolean stripIllegalXmlChars = null;
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      Document doc = transform(msg);
+      writeXmlDocument(doc, msg);
+    }
+    catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+
+  protected abstract Document transform(AdaptrisMessage msg) throws ServiceException;
+
+  protected boolean stripIllegalXmlChars() {
+    return BooleanUtils.toBooleanDefaultIfNull(getStripIllegalXmlChars(), true);
+  }
+
+  protected Node createTextNode(Document doc, String value) {
+    String v = StringUtils.defaultIfEmpty(value, "");
+    String munged = stripIllegalXmlChars() ? XmlHelper.stripIllegalXmlCharacters(v) : v;
+    return doc.createTextNode(munged);
+  }
+
+  protected Element addNewElement(Document doc, Element parent, String name) {
+    Element newElement = doc.createElement(name);
+    parent.appendChild(newElement);
+    return newElement;
+  }
+
+  /**
+   * Helper method to write the XML document to the AdaptrisMessage taking into account any encoding requirements.
+   *
+   * @param doc the XML document
+   * @param msg the AdaptrisMessage
+   * @throws Exception
+   */
+  protected void writeXmlDocument(Document doc, AdaptrisMessage msg) throws Exception {
+    try (OutputStream out = msg.getOutputStream()) {
+      String encoding = evaluateEncoding(msg);
+      new XmlUtils().writeDocument(doc, out, encoding);
+      msg.setContentEncoding(encoding);
+    }
+  }
+
+  protected CsvPreference buildPreferences() {
+    return ObjectUtils.defaultIfNull(getPreferenceBuilder(),
+        new BasicPreferenceBuilder(Style.STANDARD_PREFERENCE)).build();
+  }
+}

--- a/src/main/java/com/adaptris/csv/transform/CsvXmlTransformImpl.java
+++ b/src/main/java/com/adaptris/csv/transform/CsvXmlTransformImpl.java
@@ -1,0 +1,100 @@
+package com.adaptris.csv.transform;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.BooleanUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.util.XmlHelper;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Base class for transforming CSV into XML.
+ *
+ */
+@NoArgsConstructor
+public abstract class CsvXmlTransformImpl extends ServiceImp {
+
+  protected static final String CSV_RECORD_NAME = "record";
+  protected static final String XML_ROOT_ELEMENT = "csv-xml";
+  protected static final String CSV_FIELD_NAME = "csv-field";
+
+  /**
+   * Set the encoding for the resulting XML document.
+   * <p>
+   * If not specified the following rules will be applied:
+   * </p>
+   * <ol>
+   * <li>If the {@link AdaptrisMessage#getCharEncoding()} is non-null then that will be used.</li>
+   * <li>UTF-8</li>
+   * </ol>
+   * <p>
+   * As a result; the character encoding on the message is always set using
+   * {@link AdaptrisMessage#setCharEncoding(String)}.
+   * </p>
+   *
+   */
+  @AdvancedConfig
+  @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  private String outputMessageEncoding = null;
+  /**
+   * Specify whether or not to include the line number as an attribute on each record.
+   *
+   *
+   */
+  @InputFieldDefault(value = "false")
+  @Getter
+  @Setter
+  private Boolean includeLineNumberAttribute = null;
+
+  @Override
+  protected void initService() throws CoreException {}
+
+  @Override
+  protected void closeService() {
+
+  }
+
+  @Override
+  public void prepare() throws CoreException {}
+
+
+  protected String evaluateEncoding(AdaptrisMessage msg) {
+    String encoding = "UTF-8";
+    if (!isEmpty(getOutputMessageEncoding())) {
+      encoding = defaultIfEmpty(msg.resolve(getOutputMessageEncoding()), "UTF-8");
+    }
+    else if (!isEmpty(msg.getContentEncoding())) {
+      encoding = msg.getContentEncoding();
+    }
+    return encoding;
+  }
+
+  protected boolean includeLineNumberAttribute() {
+    return BooleanUtils.toBooleanDefaultIfNull(getIncludeLineNumberAttribute(), false);
+  }
+
+
+  protected static String[] safeElementNames(String[] input) {
+    for (int i = 0; i < input.length; i++) {
+      input[i] = XmlHelper.safeElementName(input[i], "blank");
+    }
+    return input;
+  }
+
+  protected static List<String> safeElementNames(List<String> input) {
+    return input.stream().map((s) -> XmlHelper.safeElementName(s, "blank"))
+        .collect(Collectors.toList());
+  }
+
+}

--- a/src/main/java/com/adaptris/csv/transform/StreamingCsvToXml.java
+++ b/src/main/java/com/adaptris/csv/transform/StreamingCsvToXml.java
@@ -1,0 +1,202 @@
+package com.adaptris.csv.transform;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Map;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.xml.stream.XMLStreamWriter;
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.core.util.XmlHelper;
+import com.adaptris.csv.BasicPreferenceBuilder;
+import com.adaptris.csv.OrderedCsvMapReader;
+import com.adaptris.csv.PreferenceBuilder;
+import com.adaptris.stax.DefaultWriterFactory;
+import com.adaptris.stax.StreamWriterFactory;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NonNull;
+
+/**
+ * CSV to XML using {@code net.sf.supercsv:super-csv} via {@link XMLStreamWriter}
+ *
+ * <p>
+ * This transformation uses {@code net.sf.supercsv:super-csv} as the parsing engine for a CSV file and uses {@link XMLStreamWriter}
+ * via {@code com.adaptris:interlok-stax} to write each row as part of an XML document. It may have better performance
+ * characteristics with large CSV files compared to {@link CsvToXml}. It also reduces the number of
+ * configuration options that are available.
+ * <p>
+ * Element names are always generated from the first line; so a header line is always assumed; Note that if your header rows
+ * contains characters that would not be allowed in an standard XML element name then it will be replaced with an '_', so "Order
+ * Date" becomes "Order_Date". Additionally illegal XML characters are always stripped (illegal characters would cause an exception
+ * regardless in the {@link XMLStreamWriter}).
+ * </p>
+ * <p>
+ * For example, given an input document :
+ *
+ * <pre>
+ * <code>
+Event Name,Order Date,Ticket Type,Date Attending,Total Paid
+Glastonbury,"Sep 15, 2012",Free entry,"Jun 26, 2014 at 6:00 PM",0
+Reading Festival,"Sep 16, 2012",Free entry,"Aug 30, 2014 at 6:00 PM",0
+ * </code> </pre> Then the output (without a header row) would be
+ *
+ * <pre>
+ * <code>
+ * &lt;csv-xml>
+ *   &lt;record line="1">
+ *     &lt;Event_Name>Glastonbury&lt;/Event_Name>
+ *     &lt;Order_Date>Sep 15, 2012&lt;/Order_Date>
+ *     &lt;Ticket_Type>Free entry&lt;/Ticket_Type>
+ *     &lt;Date_Attending>Jun 26, 2014 at 6:00 PM&lt;/Date_Attending>
+ *     &lt;Total_Paid>0&lt;/Total_Paid>
+ *   &lt;/record>
+ *   &lt;record line="2">
+ *     &lt;Event_Name>Reading Festival&lt;/Event_Name>
+ *     &lt;Order_Date>Sep 16, 2012&lt;/Order_Date>
+ *     &lt;Ticket_Type>Free entry&lt;/Ticket_Type>
+ *     &lt;Date_Attending>Aug 30, 2014 at 6:00 PM&lt;/Date_Attending>
+ *     &lt;Total_Paid>0&lt;/Total_Paid>
+ *   &lt;/record>
+ * </code> </pre>
+ *
+ * @config streaming-csv-to-xml-transform
+ *
+ */
+@XStreamAlias("streaming-csv-to-xml-transform")
+@AdapterComponent
+@ComponentProfile(summary = "Transform CSV to XML using the XML streaming API (STaX).",
+    tag = "service,transform,csv,xml", since = "3.11.0")
+@DisplayOrder(order = {"preferenceBuilder", "outputMessageEncoding", "streamWriterFactory"})
+public class StreamingCsvToXml extends CsvXmlTransformImpl {
+
+  @NotNull
+  @AutoPopulated
+  @Valid
+  @InputFieldDefault(value = "csv-basic-preference-builder")
+  @NonNull
+  private PreferenceBuilder preferenceBuilder;
+
+  @Valid
+  @AdvancedConfig
+  @InputFieldDefault(value = "stax-default-stream-writer")
+  private StreamWriterFactory streamWriter;
+
+  public StreamingCsvToXml() {
+    setPreferenceBuilder(new BasicPreferenceBuilder(BasicPreferenceBuilder.Style.STANDARD_PREFERENCE));
+  }
+
+  public StreamingCsvToXml(PreferenceBuilder prefs, StreamWriterFactory fact) {
+    this();
+    setPreferenceBuilder(prefs);
+    setStreamWriter(fact);
+  }
+
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
+    StreamWriterFactory writerFactory = writerFactory();
+    XMLStreamWriter xmlWriter = null;
+    int count = 0;
+    long start = System.currentTimeMillis();
+    try {
+      String encoding = evaluateEncoding(msg);
+      try (Reader reader = new BufferedReader(msg.getReader());
+          OrderedCsvMapReader csvReader = new OrderedCsvMapReader(reader, getPreferenceBuilder().build());
+          Writer writer = new BufferedWriter(msg.getWriter(encoding))) {
+
+        xmlWriter = writerFactory.create(writer);
+        log.trace("Using {}", xmlWriter.getClass().getName());
+        xmlWriter.writeStartDocument(encoding, "1.0");
+        xmlWriter.writeStartElement(XML_ROOT_ELEMENT);
+        String[] hdrs = safeElementNames(csvReader.getHeader(true));
+        for (Map<String, String> row; (row = csvReader.read(hdrs)) != null;) {
+          xmlWriter.writeStartElement(CSV_RECORD_NAME);
+          count++;
+          if (includeLineNumberAttribute()) {
+            xmlWriter.writeAttribute("line", String.valueOf(count));
+          }
+          for (Map.Entry<String, String> entry : row.entrySet()) {
+            String elementData = XmlHelper.stripIllegalXmlCharacters(defaultIfEmpty(entry.getValue(), ""));
+            if (!isEmpty(elementData)) {
+              xmlWriter.writeStartElement(entry.getKey());
+              xmlWriter.writeCharacters(XmlHelper.stripIllegalXmlCharacters(entry.getValue()));
+              xmlWriter.writeEndElement();
+            }
+            else {
+              xmlWriter.writeEmptyElement(entry.getKey());
+            }
+          }
+          xmlWriter.writeEndElement();
+        }
+        xmlWriter.writeEndElement();
+        xmlWriter.writeEndDocument();
+      }
+      msg.setContentEncoding(encoding);
+    }
+    catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+    finally {
+      writerFactory.close(xmlWriter);
+    }
+    log.trace("Converted {} rows to XML in {}ms", count, System.currentTimeMillis() - start);
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+  }
+
+  @Override
+  protected void closeService() {
+  }
+
+  public PreferenceBuilder getPreferenceBuilder() {
+    return preferenceBuilder;
+  }
+
+  public void setPreferenceBuilder(PreferenceBuilder b) {
+    preferenceBuilder = Args.notNull(b, "preferenceBuilder");
+  }
+
+  /**
+   * @return the streamWriterFactory
+   */
+  public StreamWriterFactory getStreamWriter() {
+    return streamWriter;
+  }
+
+  /**
+   * Set the stream writer factory to use.
+   *
+   * @param factory the streamWriterFactory to set, default is {@link DefaultWriterFactory} if not specified.
+   */
+  public void setStreamWriter(StreamWriterFactory factory) {
+    streamWriter = factory;
+  }
+
+  StreamWriterFactory writerFactory() {
+    return ObjectUtils.defaultIfNull(getStreamWriter(), new DefaultWriterFactory());
+  }
+
+}

--- a/src/main/java/com/adaptris/csv/transform/UncheckedCsvToXml.java
+++ b/src/main/java/com/adaptris/csv/transform/UncheckedCsvToXml.java
@@ -1,0 +1,138 @@
+package com.adaptris.csv.transform;
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.csv.OrderedCsvMapReader;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
+
+/**
+ * Unchecked CSV to XML using {@code net.sf.supercsv:super-csv} that replaces
+ * {@link com.adaptris.core.transform.csv.RawCsvToXmlTransformService}.
+ *
+ * <p>
+ * This service does not attempt to make parsing decisions, so CSV files that have differing number
+ * of columns on each line would be perfectly acceptable.
+ * </p>
+ * <p>
+ * For example, given an input document :
+ *
+ * <pre>
+ * {@code
+HEADER,19052017
+PRODUCT-CODE,BARCODE,DP,PROMPRICE,DISCOUNT,INSTOCK,REPORT,REPORT-DATE,SOURCE
+XXXXXXXX,1234567890123,2.75,0.00,5.00,2,,,GSL
+TRAILER,4
+   }
+ * </pre>
+ *
+ * Then the output would be
+ *
+ * <pre>
+ * {@code
+  <csv-xml>
+   <record>
+      <csv-field-1>HEADER<csv-field-1>
+      <csv-field-2>19052017</csv-field-2>
+   </record>
+   <record>
+      <csv-field-1>PRODUCT-CODE<csv-field-1>
+      <csv-field-2>BARCODE</csv-field-2>
+      <csv-field-3>DP</csv-field-3>
+      <csv-field-4>PROMPRICE</csv-field-4>
+      <csv-field-5>DISCOUNT</csv-field-5>
+      <csv-field-6>INSTOCK</csv-field-6>
+      <csv-field-7>REPORT</csv-field-7>
+      <csv-field-8>REPORT-DATE</csv-field-8>
+      <csv-field-9>SOURCE</csv-field-9>
+   </record>
+   <record>
+      <csv-field-1>XXXXXXXX<csv-field-1>
+      <csv-field-2>1234567890123</csv-field-2>
+      <csv-field-3>,2.75</csv-field-3>
+      <csv-field-4>0.00</csv-field-4>
+      <csv-field-5>5.00</csv-field-5>
+      <csv-field-6>2</csv-field-6>
+      <csv-field-7></csv-field-7>
+      <csv-field-8></csv-field-8>
+      <csv-field-9>GSL</csv-field-9>
+   </record>
+   <record>
+      <csv-field-1>TRAILER<csv-field-1>
+      <csv-field-2>4</csv-field-2>
+   </record>
+  </csv-xml>
+}
+ * </pre>
+ * </p>
+ * <p>
+ * Because there is no verification that the CSV columns matchup; if the message type isn't a CSV
+ * (e.g. it's JSON or XML), then it will still be marked up into XML, so take that into account when
+ * using this as part of a workflow. Behaviour with rogue messages may not be as you expect.
+ * </p>
+ *
+ * @config unchecked-csv-to-xml-transform
+ */
+@XStreamAlias("unchecked-csv-to-xml-transform")
+@AdapterComponent
+@ComponentProfile(summary = "Easily transform a document from CSV to XML",
+    tag = "service,transform,csv,xml", since = "3.11.0")
+@DisplayOrder(order = {"format", "outputMessageEncoding", "stripIllegalXmlChars"})
+@NoArgsConstructor
+public class UncheckedCsvToXml extends CsvToXmlServiceImpl {
+
+
+  @Override
+  protected Document transform(AdaptrisMessage msg) throws ServiceException {
+    Document doc = null;
+    try (Reader in = msg.getReader();
+        OrderedCsvMapReader csvReader =
+            new OrderedCsvMapReader(in, buildPreferences());) {
+      doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+      Element root = doc.createElement(XML_ROOT_ELEMENT);
+      doc.appendChild(root);
+      int recordCount = 1;
+      for (List<String> record; (record = csvReader.readNext()) != null;) {
+        Element recordElement = addNewElement(doc, root, CSV_RECORD_NAME);
+        if (includeLineNumberAttribute()) {
+          recordElement.setAttribute("line", String.valueOf(recordCount));
+        }
+        // Create the sub doc here.
+        List<Element> csvFields = createFields(doc, record);
+        for (Element field : csvFields) {
+          recordElement.appendChild(field);
+        }
+        recordCount++;
+      }
+    }
+    catch (Exception e) {
+      throw new ServiceException("Failed to convert CSV to XML", e);
+    }
+    return doc;
+  }
+
+
+  private static final String createElementName(int count) {
+    return CSV_FIELD_NAME + "-" + (count + 1);
+  }
+
+  private List<Element> createFields(Document doc, List<String> record) {
+    List<Element> result = new ArrayList<>();
+    for (int i = 0; i < record.size(); i++) {
+      Element element = doc.createElement(createElementName(i));
+      element.appendChild(createTextNode(doc, record.get(i)));
+      result.add(element);
+    }
+    return result;
+  }
+
+}

--- a/src/main/java/com/adaptris/csv/transform/package-info.java
+++ b/src/main/java/com/adaptris/csv/transform/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * <p>
+ * Transformation of CSV files into XML.
+ * </p>
+ */
+package com.adaptris.csv.transform;

--- a/src/test/java/com/adaptris/core/transform/csv/CsvToXmlTransformServiceTest.java
+++ b/src/test/java/com/adaptris/core/transform/csv/CsvToXmlTransformServiceTest.java
@@ -15,6 +15,7 @@ import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
 
+@SuppressWarnings("deprecation")
 public class CsvToXmlTransformServiceTest extends TransformServiceExample {
 
   public static final String LINE_ENDING = System.getProperty("line.separator");
@@ -159,7 +160,7 @@ public class CsvToXmlTransformServiceTest extends TransformServiceExample {
     assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[3]/csv-field-2"));
     assertEquals("UTF-8", msg.getContentEncoding());
   }
-  
+
   @Test
   public void testDoService_NonUniqueRecords_IncludeLineNumberAttribute() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
@@ -173,7 +174,7 @@ public class CsvToXmlTransformServiceTest extends TransformServiceExample {
     assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='3']/csv-field-2"));
     assertEquals("UTF-8", msg.getContentEncoding());
   }
-  
+
 
   @Test
   public void testDoService_RFC4180() throws Exception {

--- a/src/test/java/com/adaptris/core/transform/csv/CustomFormatBuilderTest.java
+++ b/src/test/java/com/adaptris/core/transform/csv/CustomFormatBuilderTest.java
@@ -4,12 +4,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-
 import org.apache.commons.csv.CSVFormat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class CustomFormatBuilderTest {
 
   @Before

--- a/src/test/java/com/adaptris/core/transform/csv/RawCsvToXmlTransformServiceTest.java
+++ b/src/test/java/com/adaptris/core/transform/csv/RawCsvToXmlTransformServiceTest.java
@@ -13,20 +13,21 @@ import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
 
+@SuppressWarnings("deprecation")
 public class RawCsvToXmlTransformServiceTest extends TransformServiceExample {
 
   private static final String LINE_ENDING = System.getProperty("line.separator");
 
   private static final String CSV_INPUT =
-        "HEADER,19052017" + LINE_ENDING 
+        "HEADER,19052017" + LINE_ENDING
       + "PRODUCT-CODE,BARCODE,DP,PROMPRICE,DISCOUNT,INSTOCK,REPORT,REPORT-DATE,SOURCE" + LINE_ENDING
       + "XXXXXXXX,1234567890123,2.75,0.00,5.00,2,,,GSL" + LINE_ENDING
       + "YYYYYYYY,1234567890123,20.42,0.00,5.00,0,NYP,24/07/2017,GSL" + LINE_ENDING
       + "AAAAAAAA,1234567890123,2.75,0.00,5.00,88,O/P,13/03/2017,GSL" + LINE_ENDING
-      + "BBBBBBBB,1234567890123,3.60,2.94,5.00,21,,,GSL" + LINE_ENDING 
+      + "BBBBBBBB,1234567890123,3.60,2.94,5.00,21,,,GSL" + LINE_ENDING
       + "TRAILER,4" + LINE_ENDING;
 
-  private static final String NOT_CSV = 
+  private static final String NOT_CSV =
         "<hello>" + LINE_ENDING
       + "abc,def" + LINE_ENDING
       + "</hello>";
@@ -41,7 +42,7 @@ public class RawCsvToXmlTransformServiceTest extends TransformServiceExample {
   public boolean isAnnotatedForJunit4() {
     return true;
   }
-  
+
   @Test
   public void testDoService() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
@@ -68,7 +69,7 @@ public class RawCsvToXmlTransformServiceTest extends TransformServiceExample {
     assertEquals("YYYYYYYY", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='4']/csv-field-1"));
     assertEquals("UTF-8", msg.getContentEncoding());
   }
-  
+
   @Test
   public void testDoService_Exception() throws Exception {
     AdaptrisMessage msg = new DefectiveMessageFactory().newMessage(CSV_INPUT);

--- a/src/test/java/com/adaptris/core/transform/csv/StreamingCsvToXmlTest.java
+++ b/src/test/java/com/adaptris/core/transform/csv/StreamingCsvToXmlTest.java
@@ -1,34 +1,18 @@
 package com.adaptris.core.transform.csv;
 
-import static com.adaptris.core.transform.csv.CsvToXmlTransformServiceTest.CSV_ILLEGAL;
 import static com.adaptris.core.transform.csv.CsvToXmlTransformServiceTest.CSV_INPUT;
-import static com.adaptris.core.transform.csv.CsvToXmlTransformServiceTest.CSV_INPUT_ILLEGAL_HEADER;
 import static com.adaptris.core.transform.csv.CsvToXmlTransformServiceTest.LINE_ENDING;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import java.io.FilterInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.DefaultAdaptrisMessageImp;
-import com.adaptris.core.DefaultMessageFactory;
-import com.adaptris.core.ServiceException;
 import com.adaptris.core.transform.TransformServiceExample;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.XmlHelper;
-import com.adaptris.csv.BasicPreferenceBuilder;
-import com.adaptris.stax.SaxonStreamWriterFactory;
-import com.adaptris.util.IdGenerator;
-import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.text.xml.XPath;
-import net.sf.saxon.s9api.Serializer;
 
+@Deprecated
 public class StreamingCsvToXmlTest extends TransformServiceExample {
 
   public static final String CSV_INPUT_EMPTY_FIELD = "Name,Order Date,Date Attending,Total Paid" + LINE_ENDING
@@ -55,41 +39,6 @@ public class StreamingCsvToXmlTest extends TransformServiceExample {
   }
 
   @Test
-  public void testSetDocumentFormatBuilder() throws Exception {
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    assertNotNull(svc.getPreferenceBuilder());
-    assertEquals(BasicPreferenceBuilder.class, svc.getPreferenceBuilder().getClass());
-
-    try {
-      svc.setPreferenceBuilder(null);
-      fail();
-    }
-    catch (IllegalArgumentException e) {
-
-    }
-    assertEquals(BasicPreferenceBuilder.class, svc.getPreferenceBuilder().getClass());
-  }
-
-  @Test
-  public void testSetOutputEncoding() throws Exception {
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    assertNull(svc.getOutputMessageEncoding());
-
-    svc.setOutputMessageEncoding("UTF-8");
-    assertEquals("UTF-8", svc.getOutputMessageEncoding());
-  }
-
-  @Test
-  public void testDoService_IllegalHeaders() throws Exception {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT_ILLEGAL_HEADER);
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    execute(svc, msg);
-    XPath xpath = new XPath();
-    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
-    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date_"));
-  }
-
-  @Test
   public void testDoService_Defaults() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
     StreamingCsvToXml svc = new StreamingCsvToXml();
@@ -100,125 +49,7 @@ public class StreamingCsvToXmlTest extends TransformServiceExample {
     assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
     assertEquals("UTF-8", msg.getContentEncoding());
   }
-  
-  @Test
-  public void testDoService_IncludeLineNumberAttribute() throws Exception {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    svc.setIncludeLineNumberAttribute(true);
-    execute(svc, msg);
-    XPath xpath = new XPath();
-    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
-    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='1']/Order_Date"));
-    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='2']/Order_Date"));
-    assertEquals("UTF-8", msg.getContentEncoding());
-  }
-  
-  @Test
-  public void testDoService_SaxonWriter() throws Exception {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
-    StreamingCsvToXml svc = new StreamingCsvToXml(new BasicPreferenceBuilder(),
-        new SaxonStreamWriterFactory(new KeyValuePair(Serializer.Property.INDENT.name(), "yes")));
-    execute(svc, msg);
-    System.err.println(msg.getContent());
-    XPath xpath = new XPath();
-    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
-    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
-    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
-    assertEquals("UTF-8", msg.getContentEncoding());
-  }
 
-  @Test
-  public void testDoService_BrokenInput() throws Exception {
-    AdaptrisMessage msg = new BrokenMessageFactory(WhenToBreak.INPUT).newMessage(CSV_INPUT);
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    try {
-      execute(svc, msg);
-      fail();
-    } catch (ServiceException expected) {
-
-    }
-  }
-
-  @Test
-  public void testDoService_BrokenOutput() throws Exception {
-    AdaptrisMessage msg = new BrokenMessageFactory(WhenToBreak.OUTPUT).newMessage(CSV_INPUT);
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    try {
-      execute(svc, msg);
-      fail();
-    } catch (ServiceException expected) {
-
-    }
-  }
-
-  @Test
-  public void testDoService_EmptyField() throws Exception {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT_EMPTY_FIELD);
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    execute(svc, msg);
-    XPath xpath = new XPath();
-    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
-    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
-    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
-    // Should be empty not null.
-    assertEquals("", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Date_Attending"));
-    assertEquals("", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Date_Attending"));
-    assertEquals("UTF-8", msg.getContentEncoding());
-  }
-
-  @Test
-  public void testDoService_IllegalXml() throws Exception {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_ILLEGAL);
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    execute(svc, msg);
-    XPath xpath = new XPath();
-    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
-    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
-    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
-    assertEquals("UTF-8", msg.getContentEncoding());
-  }
-
-  @Test
-  public void testDoService_MessageIsEncoded() throws Exception {
-    DefaultMessageFactory fact = new DefaultMessageFactory();
-    fact.setDefaultCharEncoding("ISO-8859-1");
-    AdaptrisMessage msg = fact.newMessage(CSV_INPUT);
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    execute(svc, msg);
-    XPath xpath = new XPath();
-    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
-    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
-    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
-    assertEquals("ISO-8859-1", msg.getContentEncoding());
-  }
-
-  @Test
-  public void testDoService_OutputEncoding() throws Exception {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    svc.setOutputMessageEncoding("ISO-8859-1");
-    execute(svc, msg);
-    XPath xpath = new XPath();
-    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
-    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
-    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
-    assertEquals("ISO-8859-1", msg.getContentEncoding());
-  }
-
-  @Test
-  public void testDoService_InvalidOutputEncoding() throws Exception {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
-    StreamingCsvToXml svc = new StreamingCsvToXml();
-    svc.setOutputMessageEncoding("ISO-8849-1");
-    try {
-      execute(svc, msg);
-      fail();
-    }
-    catch (ServiceException expected) {
-
-    }
-  }
 
   @Override
   protected StreamingCsvToXml retrieveObjectForSampleConfig() {
@@ -230,96 +61,4 @@ public class StreamingCsvToXmlTest extends TransformServiceExample {
     return super.getExampleCommentHeader(o) + EXAMPLE_COMMENT_HEADER;
   }
 
-  protected class BrokenMessageFactory extends DefaultMessageFactory {
-
-    private WhenToBreak when;
-
-    public BrokenMessageFactory(WhenToBreak w) {
-      this.when = w;
-    }
-
-    @Override
-    public AdaptrisMessage newMessage() {
-      AdaptrisMessage result = new BrokenMessage(uniqueIdGenerator(), this);
-      return result;
-    }
-
-    boolean brokenInput() {
-      return (when == WhenToBreak.INPUT) || (when == WhenToBreak.BOTH);
-    }
-
-    boolean brokenOutput() {
-      return (when == WhenToBreak.OUTPUT) || (when == WhenToBreak.BOTH);
-    }
-
-  }
-
-
-  public class BrokenMessage extends DefaultAdaptrisMessageImp {
-
-    protected BrokenMessage(IdGenerator guid, AdaptrisMessageFactory amf) throws RuntimeException {
-      super(guid, amf);
-      setPayload(new byte[0]);
-    }
-
-    /**
-     *
-     * @see com.adaptris.core.AdaptrisMessage#getInputStream()
-     */
-    @Override
-    public InputStream getInputStream() throws IOException {
-      if (((BrokenMessageFactory) getFactory()).brokenInput()) {
-        return new ErroringInputStream(super.getInputStream());
-      }
-      return super.getInputStream();
-    }
-
-    /**
-     *
-     * @see com.adaptris.core.AdaptrisMessage#getOutputStream()
-     */
-    @Override
-    public OutputStream getOutputStream() throws IOException {
-      if (((BrokenMessageFactory) getFactory()).brokenOutput()) {
-        return new ErroringOutputStream();
-      }
-      return super.getOutputStream();
-    }
-
-    private class ErroringOutputStream extends OutputStream {
-
-      protected ErroringOutputStream() {
-        super();
-      }
-
-      @Override
-      public void write(int b) throws IOException {
-        throw new IOException("Failed to write");
-      }
-
-    }
-
-    private class ErroringInputStream extends FilterInputStream {
-
-      protected ErroringInputStream(InputStream in) {
-        super(in);
-      }
-
-      @Override
-      public int read() throws IOException {
-        throw new IOException("Failed to read");
-      }
-
-      @Override
-      public int read(byte[] b) throws IOException {
-        throw new IOException("Failed to read");
-      }
-
-      @Override
-      public int read(byte[] b, int off, int len) throws IOException {
-        throw new IOException("Failed to read");
-      }
-
-    }
-  }
 }

--- a/src/test/java/com/adaptris/csv/BasicPreferenceBuilderTest.java
+++ b/src/test/java/com/adaptris/csv/BasicPreferenceBuilderTest.java
@@ -1,0 +1,15 @@
+package com.adaptris.csv;
+
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+public class BasicPreferenceBuilderTest {
+
+  @Test
+  public void testBuild() throws Exception {
+    for (BasicPreferenceBuilder.Style s : BasicPreferenceBuilder.Style.values()) {
+      BasicPreferenceBuilder b = new BasicPreferenceBuilder(s);
+      assertNotNull(b.build());
+    }
+  }
+}

--- a/src/test/java/com/adaptris/csv/IterableOrderedCsvMapReaderTest.java
+++ b/src/test/java/com/adaptris/csv/IterableOrderedCsvMapReaderTest.java
@@ -1,18 +1,18 @@
 package com.adaptris.csv;
 
-import org.junit.Test;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
-
-import static com.adaptris.core.transform.csv.CsvToXmlTransformServiceTest.LINE_ENDING;
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * @author mwarman
  */
 public class IterableOrderedCsvMapReaderTest {
+  public static final String LINE_ENDING = System.getProperty("line.separator");
 
   private static final String CSV_INPUT_FIELD = "Name,Order Date,Date Attending,Total Paid" + LINE_ENDING
       + "Record1,\"Sep 15, 2012\",,0" + LINE_ENDING

--- a/src/test/java/com/adaptris/csv/OrderedCsvMapReaderTest.java
+++ b/src/test/java/com/adaptris/csv/OrderedCsvMapReaderTest.java
@@ -1,0 +1,43 @@
+package com.adaptris.csv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class OrderedCsvMapReaderTest {
+  public static final String LINE_ENDING = System.getProperty("line.separator");
+
+  private static final String CSV_INPUT_FIELD = "Name,Order Date,Date Attending,Total Paid" + LINE_ENDING
+      + "Record1,\"Sep 15, 2012\",,0" + LINE_ENDING
+      + "Record2,\"Sep 16, 2012\",,0" + LINE_ENDING
+      + "Record3,\"Sep 17, 2012\",,0" + LINE_ENDING;
+
+  @Test
+  public void testRead() throws Exception {
+    try (OrderedCsvMapReader csvReader = new OrderedCsvMapReader(
+        new StringReader(CSV_INPUT_FIELD), new BasicPreferenceBuilder().build())) {
+      String[] hdrs = csvReader.getHeader(true);
+      for (Map<String, String> record; (record = csvReader.read(hdrs)) != null;) {
+        assertTrue(record.containsKey("Name"));
+        assertTrue(record.containsKey("Order Date"));
+        assertTrue(record.containsKey("Date Attending"));
+        assertTrue(record.containsKey("Total Paid"));
+      }
+    }
+  }
+
+  @Test
+  public void testReadNext() throws Exception {
+    try (OrderedCsvMapReader csvReader = new OrderedCsvMapReader(new StringReader(CSV_INPUT_FIELD),
+        new BasicPreferenceBuilder().build())) {
+      int recordCount = 0;
+      for (List<String> record; (record = csvReader.readNext()) != null;) {
+        recordCount++;
+      }
+      assertEquals(4, recordCount);
+    }
+  }
+}

--- a/src/test/java/com/adaptris/csv/aggregator/CsvAggregatorTest.java
+++ b/src/test/java/com/adaptris/csv/aggregator/CsvAggregatorTest.java
@@ -1,7 +1,6 @@
 package com.adaptris.csv.aggregator;
 
 import static org.junit.Assert.assertEquals;
-
 import java.io.StringReader;
 import java.util.Arrays;
 import java.util.List;
@@ -65,7 +64,8 @@ public class CsvAggregatorTest {
     assertEquals("k1", actualLines.get(1));
     assertEquals("k2,v2", actualLines.get(2));
     assertEquals("k4,v4,z4", actualLines.get(3));
-    assertEquals("\"\",", actualLines.get(4)); // forced an empty value
+    // This isn't true, since empty values don't render with super-csv
+    // assertEquals("\"\",", actualLines.get(4)); // forced an empty value
     assertEquals("k6,v6", actualLines.get(5));
   }
 }

--- a/src/test/java/com/adaptris/csv/splitter/CsvMetadataSplitterTest.java
+++ b/src/test/java/com/adaptris/csv/splitter/CsvMetadataSplitterTest.java
@@ -1,5 +1,5 @@
 package com.adaptris.csv.splitter;
-import static com.adaptris.core.transform.csv.CsvToXmlTransformServiceTest.LINE_ENDING;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import java.util.List;
@@ -13,6 +13,7 @@ import com.adaptris.interlok.util.CloseableIterable;
  * @author mwarman
  */
 public class CsvMetadataSplitterTest {
+  public static final String LINE_ENDING = System.getProperty("line.separator");
 
   private static final String CSV_INPUT_FIELD = "Name,Order Date,Date Attending,Total Paid" + LINE_ENDING
       + "Record1,\"Sep 15, 2012\",,0" + LINE_ENDING

--- a/src/test/java/com/adaptris/csv/transform/CsvToXmlTest.java
+++ b/src/test/java/com/adaptris/csv/transform/CsvToXmlTest.java
@@ -1,0 +1,286 @@
+package com.adaptris.csv.transform;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
+import com.adaptris.core.util.XmlHelper;
+import com.adaptris.csv.BasicPreferenceBuilder;
+import com.adaptris.csv.CustomPreferenceBuilder;
+import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
+import com.adaptris.util.text.xml.XPath;
+
+public class CsvToXmlTest extends TransformServiceExample {
+
+  public static final String LINE_ENDING = System.getProperty("line.separator");
+  public static final String ILLEGAL_XML_CHAR = new String(new byte[]
+  {
+    (byte) 0x02
+  });
+
+  public static final String CSV_INPUT_ILLEGAL_HEADER = "Name?,Order Date#,Date Attending,Total Paid" + ILLEGAL_XML_CHAR
+      + LINE_ENDING + "Record1,\"Sep 15, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING
+      + "Record2,\"Sep 16, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING
+      + "Record3,\"Sep 17, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING;
+
+  public static final String CSV_INPUT = "Name,Order Date,Date Attending,Total Paid" + LINE_ENDING
+      + "Record1,\"Sep 15, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING
+      + "Record2,\"Sep 16, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING
+      + "Record3,\"Sep 17, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING;
+
+  public static final String CSV_ILLEGAL = "Name,Order Date,Date Attending,Total Paid" + LINE_ENDING
+      + "Record1,\"Sep 15, 2012\",\"Oct 22, 2012 at 6:00 PM\"," + ILLEGAL_XML_CHAR + "" + LINE_ENDING
+      + "Record2,\"Sep 16, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING
+      + "Record3,\"Sep 17, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING;
+
+  public static final String CSV_TAB = "Name\tOrder Date\tDate Attending\tTotal Paid" + LINE_ENDING
+      + "Record1\t\"Sep 15, 2012\"\t\"Oct 22, 2012 at 6:00 PM\"\t0" + LINE_ENDING
+      + "Record2\t\"Sep 16, 2012\"\t\"Oct 22, 2012 at 6:00 PM\"\t0" + LINE_ENDING
+      + "Record3\t\"Sep 17, 2012\"\t\"Oct 22, 2012 at 6:00 PM\"\t0" + LINE_ENDING;
+
+  public static final String CSV_BLANK_HDR = "Name,,Date Attending,Total Paid" + LINE_ENDING
+      + "Record1,\"Sep 15, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING
+      + "Record2,\"Sep 16, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING
+      + "Record3,\"Sep 17, 2012\",\"Oct 22, 2012 at 6:00 PM\",0" + LINE_ENDING;
+
+  private static final String EXAMPLE_COMMENT_HEADER = "\n<!--"
+      + "\nThis is a simple CSV to XML transformation service; based on commons-csv"
+      + "\nThe styles can be configured but popular defaults are"
+      + "\navailable: DEFAULT, RFC4180, MYSQL, EXCEL and TAB_DELIMITED" + "\n"
+      + "\nIf you wish to have complex transformation rules then you"
+      + "\nshould be looking to use our flat file based transformation engine" + "\ninstead" + "\n-->\n";
+
+
+  @Test
+  public void testDoService_IllegalHeaders() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT_ILLEGAL_HEADER);
+    CsvToXml svc = new CsvToXml();
+    svc.setStripIllegalXmlChars(true);
+    svc.setUniqueRecordNames(true);
+    svc.setElementNamesFromFirstRecord(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-1/Order_Date_"));
+  }
+
+  @Test
+  public void testDoService_DefaultStyle() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    CsvToXml svc = new CsvToXml();
+    svc.setUniqueRecordNames(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Order Date", xpath.selectSingleTextItem(doc, "/csv-xml/record-1/csv-field-2"));
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-2/csv-field-2"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-3/csv-field-2"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_NonUniqueRecords() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    CsvToXml svc = new CsvToXml();
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Order Date", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/csv-field-2"));
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/csv-field-2"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[3]/csv-field-2"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_NonUniqueRecords_IncludeLineNumberAttribute() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    CsvToXml svc = new CsvToXml();
+    svc.setIncludeLineNumberAttribute(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Order Date", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='1']/csv-field-2"));
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='2']/csv-field-2"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='3']/csv-field-2"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+
+  @Test
+  public void testDoService_Excel() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    CsvToXml svc = new CsvToXml();
+    svc.setPreferenceBuilder(
+        new BasicPreferenceBuilder(BasicPreferenceBuilder.Style.EXCEL_PREFERENCE));
+    svc.setUniqueRecordNames(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Order Date", xpath.selectSingleTextItem(doc, "/csv-xml/record-1/csv-field-2"));
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-2/csv-field-2"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-3/csv-field-2"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_TabDelimiter() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_TAB);
+    CsvToXml svc = new CsvToXml();
+    svc.setPreferenceBuilder(
+        new BasicPreferenceBuilder(BasicPreferenceBuilder.Style.TAB_PREFERENCE));
+    svc.setUniqueRecordNames(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Order Date", xpath.selectSingleTextItem(doc, "/csv-xml/record-1/csv-field-2"));
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-2/csv-field-2"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-3/csv-field-2"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_CustomStyle() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    CustomPreferenceBuilder builder = new CustomPreferenceBuilder();
+    builder.setDelimiter(',');
+    builder.setQuoteChar('"');
+    builder.setRecordSeparator("\r\n");
+    // Should now be the same as "DEFAULT"
+    CsvToXml svc = new CsvToXml();
+    svc.setPreferenceBuilder(builder);
+    svc.setUniqueRecordNames(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Order Date", xpath.selectSingleTextItem(doc, "/csv-xml/record-1/csv-field-2"));
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-2/csv-field-2"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-3/csv-field-2"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_HeaderRow() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    CsvToXml svc = new CsvToXml();
+    svc.setElementNamesFromFirstRecord(true);
+    svc.setUniqueRecordNames(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-1/Order_Date"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_HeaderRow_BlankField() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_BLANK_HDR);
+    CsvToXml svc = new CsvToXml();
+    svc.setElementNamesFromFirstRecord(true);
+    svc.setUniqueRecordNames(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-1/blank"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_MessageIsEncoded() throws Exception {
+    DefaultMessageFactory fact = new DefaultMessageFactory();
+    fact.setDefaultCharEncoding("ISO-8859-1");
+    AdaptrisMessage msg = fact.newMessage(CSV_INPUT);
+    CsvToXml svc = new CsvToXml();
+    svc.setUniqueRecordNames(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Order Date", xpath.selectSingleTextItem(doc, "/csv-xml/record-1/csv-field-2"));
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-2/csv-field-2"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-3/csv-field-2"));
+    assertEquals("ISO-8859-1", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_OutputEncoding() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    CsvToXml svc = new CsvToXml();
+    svc.setOutputMessageEncoding("ISO-8859-1");
+    svc.setStripIllegalXmlChars(false);
+    svc.setUniqueRecordNames(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Order Date", xpath.selectSingleTextItem(doc, "/csv-xml/record-1/csv-field-2"));
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-2/csv-field-2"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record-3/csv-field-2"));
+    assertEquals("ISO-8859-1", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_InvalidOutputEncoding() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    CsvToXml svc = new CsvToXml();
+    svc.setOutputMessageEncoding("ISO-8849-1");
+    svc.setStripIllegalXmlChars(false);
+    try {
+      execute(svc, msg);
+      fail();
+    }
+    catch (ServiceException expected) {
+
+    }
+  }
+
+  @Test
+  public void testDoService_NotCSV() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("<hello>\nabc,def</hello>");
+    CsvToXml svc = new CsvToXml();
+    try {
+      // This fails because the 2nd record has "more fields" than the first.
+      execute(svc, msg);
+      fail();
+    }
+    catch (ServiceException expected) {
+
+    }
+  }
+
+  @Test
+  public void testDoService_IllegalXml() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_ILLEGAL);
+    CsvToXml svc = new CsvToXml();
+    svc.setStripIllegalXmlChars(false);
+    execute(svc, msg);
+    try {
+      // This should fail.
+      Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+      fail();
+    }
+    catch (Exception expected) {
+
+    }
+    msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_ILLEGAL);
+    svc.setStripIllegalXmlChars(true);
+    svc.setUniqueRecordNames(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("", xpath.selectSingleTextItem(doc, "/csv-xml/record-2/csv-field-4"));
+  }
+
+  @Override
+  protected CsvToXml retrieveObjectForSampleConfig() {
+    return new CsvToXml();
+  }
+
+  @Override
+  protected String getExampleCommentHeader(Object o) {
+    return super.getExampleCommentHeader(o) + EXAMPLE_COMMENT_HEADER;
+  }
+
+}

--- a/src/test/java/com/adaptris/csv/transform/StreamingCsvToXmlTest.java
+++ b/src/test/java/com/adaptris/csv/transform/StreamingCsvToXmlTest.java
@@ -1,0 +1,217 @@
+package com.adaptris.csv.transform;
+
+import static com.adaptris.csv.transform.CsvToXmlTest.CSV_ILLEGAL;
+import static com.adaptris.csv.transform.CsvToXmlTest.CSV_INPUT;
+import static com.adaptris.csv.transform.CsvToXmlTest.CSV_INPUT_ILLEGAL_HEADER;
+import static com.adaptris.csv.transform.CsvToXmlTest.LINE_ENDING;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.stubs.DefectiveMessageFactory;
+import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
+import com.adaptris.core.util.XmlHelper;
+import com.adaptris.csv.BasicPreferenceBuilder;
+import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
+import com.adaptris.stax.SaxonStreamWriterFactory;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.text.xml.XPath;
+import net.sf.saxon.s9api.Serializer;
+
+public class StreamingCsvToXmlTest extends TransformServiceExample {
+
+  public static final String CSV_INPUT_EMPTY_FIELD = "Name,Order Date,Date Attending,Total Paid" + LINE_ENDING
+      + "Record1,\"Sep 15, 2012\",,0" + LINE_ENDING
+      + "Record2,\"Sep 16, 2012\",,0" + LINE_ENDING
+      + "Record3,\"Sep 17, 2012\",,0" + LINE_ENDING;
+
+  private static final String EXAMPLE_COMMENT_HEADER = "\n<!--"
+      + "\nThis is a simple CSV to XML transformation service; based on super-csv"
+      + "\nusing XMLStreamWriter."
+      + "\nIf you wish to have complex transformation rules then you"
+      + "\nshould be looking to use our flat file based transformation engine" + "\ninstead" + "\n-->\n";
+
+  @Test
+  public void testSetDocumentFormatBuilder() throws Exception {
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    assertNotNull(svc.getPreferenceBuilder());
+    assertEquals(BasicPreferenceBuilder.class, svc.getPreferenceBuilder().getClass());
+
+    try {
+      svc.setPreferenceBuilder(null);
+      fail();
+    }
+    catch (Exception e) {
+
+    }
+    assertEquals(BasicPreferenceBuilder.class, svc.getPreferenceBuilder().getClass());
+  }
+
+  @Test
+  public void testSetOutputEncoding() throws Exception {
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    assertNull(svc.getOutputMessageEncoding());
+
+    svc.setOutputMessageEncoding("UTF-8");
+    assertEquals("UTF-8", svc.getOutputMessageEncoding());
+  }
+
+  @Test
+  public void testDoService_IllegalHeaders() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT_ILLEGAL_HEADER);
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date_"));
+  }
+
+  @Test
+  public void testDoService_Defaults() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_IncludeLineNumberAttribute() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    svc.setIncludeLineNumberAttribute(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='1']/Order_Date"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='2']/Order_Date"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_SaxonWriter() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    StreamingCsvToXml svc = new StreamingCsvToXml(new BasicPreferenceBuilder(),
+        new SaxonStreamWriterFactory(new KeyValuePair(Serializer.Property.INDENT.name(), "yes")));
+    execute(svc, msg);
+    System.err.println(msg.getContent());
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_BrokenInput() throws Exception {
+    AdaptrisMessage msg = new DefectiveMessageFactory(WhenToBreak.INPUT).newMessage(CSV_INPUT);
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    try {
+      execute(svc, msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    }
+  }
+
+  @Test
+  public void testDoService_BrokenOutput() throws Exception {
+    AdaptrisMessage msg = new DefectiveMessageFactory(WhenToBreak.OUTPUT).newMessage(CSV_INPUT);
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    try {
+      execute(svc, msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    }
+  }
+
+  @Test
+  public void testDoService_EmptyField() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT_EMPTY_FIELD);
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
+    // Should be empty not null.
+    assertEquals("", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Date_Attending"));
+    assertEquals("", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Date_Attending"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_IllegalXml() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_ILLEGAL);
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_MessageIsEncoded() throws Exception {
+    DefaultMessageFactory fact = new DefaultMessageFactory();
+    fact.setDefaultCharEncoding("ISO-8859-1");
+    AdaptrisMessage msg = fact.newMessage(CSV_INPUT);
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
+    assertEquals("ISO-8859-1", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_OutputEncoding() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    svc.setOutputMessageEncoding("ISO-8859-1");
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("Sep 15, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/Order_Date"));
+    assertEquals("Sep 16, 2012", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/Order_Date"));
+    assertEquals("ISO-8859-1", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_InvalidOutputEncoding() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    StreamingCsvToXml svc = new StreamingCsvToXml();
+    svc.setOutputMessageEncoding("ISO-8849-1");
+    try {
+      execute(svc, msg);
+      fail();
+    }
+    catch (ServiceException expected) {
+
+    }
+  }
+
+  @Override
+  protected StreamingCsvToXml retrieveObjectForSampleConfig() {
+    return new StreamingCsvToXml();
+  }
+
+  @Override
+  protected String getExampleCommentHeader(Object o) {
+    return super.getExampleCommentHeader(o) + EXAMPLE_COMMENT_HEADER;
+  }
+
+}

--- a/src/test/java/com/adaptris/csv/transform/UncheckedCsvToXmlTest.java
+++ b/src/test/java/com/adaptris/csv/transform/UncheckedCsvToXmlTest.java
@@ -1,0 +1,104 @@
+package com.adaptris.csv.transform;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.stubs.DefectiveMessageFactory;
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
+import com.adaptris.core.util.XmlHelper;
+import com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample;
+import com.adaptris.util.text.xml.XPath;
+
+public class UncheckedCsvToXmlTest extends TransformServiceExample {
+
+  private static final String LINE_ENDING = System.getProperty("line.separator");
+
+  private static final String CSV_INPUT =
+        "HEADER,19052017" + LINE_ENDING
+      + "PRODUCT-CODE,BARCODE,DP,PROMPRICE,DISCOUNT,INSTOCK,REPORT,REPORT-DATE,SOURCE" + LINE_ENDING
+      + "XXXXXXXX,1234567890123,2.75,0.00,5.00,2,,,GSL" + LINE_ENDING
+      + "YYYYYYYY,1234567890123,20.42,0.00,5.00,0,NYP,24/07/2017,GSL" + LINE_ENDING
+      + "AAAAAAAA,1234567890123,2.75,0.00,5.00,88,O/P,13/03/2017,GSL" + LINE_ENDING
+      + "BBBBBBBB,1234567890123,3.60,2.94,5.00,21,,,GSL" + LINE_ENDING
+      + "TRAILER,4" + LINE_ENDING;
+
+  private static final String NOT_CSV =
+        "<hello>" + LINE_ENDING
+      + "abc,def" + LINE_ENDING
+      + "</hello>";
+
+  private static final String EXAMPLE_COMMENT_HEADER = "\n<!--"
+      + "\nThis is a simple CSV to XML transformation service; based on commons-csv"
+      + "\nThe styles can be configured but popular defaults are"
+      + "\navailable: DEFAULT, RFC4180, MYSQL, EXCEL and TAB_DELIMITED" + "\n"
+      + "\n-->\n";
+
+
+  @Test
+  public void testDoService() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    UncheckedCsvToXml svc = new UncheckedCsvToXml();
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("19052017", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/csv-field-2"));
+    assertEquals("GSL", xpath.selectSingleTextItem(doc, "/csv-xml/record[3]/csv-field-9"));
+    assertEquals("YYYYYYYY", xpath.selectSingleTextItem(doc, "/csv-xml/record[4]/csv-field-1"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_IncludeLineNumberAttribute() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    UncheckedCsvToXml svc = new UncheckedCsvToXml();
+    svc.setIncludeLineNumberAttribute(true);
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("19052017", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='1']/csv-field-2"));
+    assertEquals("GSL", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='3']/csv-field-9"));
+    assertEquals("YYYYYYYY", xpath.selectSingleTextItem(doc, "/csv-xml/record[@line='4']/csv-field-1"));
+    assertEquals("UTF-8", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testDoService_Exception() throws Exception {
+    AdaptrisMessage msg = new DefectiveMessageFactory().newMessage(CSV_INPUT);
+    UncheckedCsvToXml svc = new UncheckedCsvToXml();
+    try {
+      execute(svc, msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    }
+  }
+
+  @Test
+  public void testDoService_NotCsv() throws Exception {
+    // This is just a 3 line CSV file... (gasp).
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(NOT_CSV);
+    UncheckedCsvToXml svc = new UncheckedCsvToXml();
+    execute(svc, msg);
+    XPath xpath = new XPath();
+    Document doc = XmlHelper.createDocument(msg, new DocumentBuilderFactoryBuilder());
+    assertEquals("<hello>", xpath.selectSingleTextItem(doc, "/csv-xml/record[1]/csv-field-1"));
+    assertEquals("def", xpath.selectSingleTextItem(doc, "/csv-xml/record[2]/csv-field-2"));
+    assertEquals("</hello>", xpath.selectSingleTextItem(doc, "/csv-xml/record[3]/csv-field-1"));
+  }
+
+
+  @Override
+  protected UncheckedCsvToXml retrieveObjectForSampleConfig() {
+    return new UncheckedCsvToXml();
+  }
+
+  @Override
+  protected String getExampleCommentHeader(Object o) {
+    return super.getExampleCommentHeader(o) + EXAMPLE_COMMENT_HEADER;
+  }
+
+}


### PR DESCRIPTION
## Motivation

We need to make a choice between commons-csv + super-csv as our "standard" CSV support since having both probably isn't a good look. There is an argument for keeping commons-csv (mysql) however, making configuration consistent should be the desired goal.

## Modification

- Deprecated the `com.adaptris.core.transform.csv.` package 
- Moved `StreamingCsvToXml` into a new `com.adaptris.csv.transform` package (since it already uses super-csv)
- Created variants of the existing transforms in `com.adaptris.csv.transform`
- CSV Aggregator now exposes super-csv configuration; one change to the tests here since super-csv doesn't emit quoted empty strings by default.

## Result

- No change other than the existing __simple-csv__ and __raw-csv__ transforms have been deprecated.
- The only change is that super-csv doesn't have a basic preference that is "MYSQL"; so we may have to revisit this.

## Testing

Where you would configure a simple-csv-to-xml configure a csv-to-xml-transform, and configure super-csv appropriately.
