### PR TITLE
INTERLOK-3424 Implement aggregate method from interface.

### DIFF
--- a/src/main/java/com/adaptris/csv/aggregator/CsvAggregating.java
+++ b/src/main/java/com/adaptris/csv/aggregator/CsvAggregating.java
@@ -9,8 +9,6 @@ import javax.validation.Valid;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.supercsv.io.CsvListWriter;
 import org.supercsv.prefs.CsvPreference;
 import com.adaptris.annotation.InputFieldDefault;
@@ -28,7 +26,6 @@ import lombok.Setter;
 
 public abstract class CsvAggregating extends MessageAggregatorImpl
 {
-  private static final transient Logger log = LoggerFactory.getLogger(CsvValidatingAggregator.class);
 
   @InputFieldHint(expression = true)
   @Getter

--- a/src/test/java/com/adaptris/csv/aggregator/CsvAggregatorTest.java
+++ b/src/test/java/com/adaptris/csv/aggregator/CsvAggregatorTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
+import com.adaptris.core.services.conditional.conditions.ConditionNever;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
 
@@ -68,4 +69,19 @@ public class CsvAggregatorTest {
     // assertEquals("\"\",", actualLines.get(4)); // forced an empty value
     assertEquals("k6,v6", actualLines.get(5));
   }
+
+  @Test
+  public void testAggregate_WithCondition() throws Exception {
+    CsvAggregator csvAggregator = new CsvAggregator().withHeader("key,value");
+    csvAggregator.setFilterCondition(new ConditionNever());
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    csvAggregator.aggregate(message,
+        Arrays.asList(AdaptrisMessageFactory.getDefaultInstance().newMessage("k1,v1\nk2,v2\n"),
+            AdaptrisMessageFactory.getDefaultInstance().newMessage("k3,v3\nk4,v4\n")));
+    List<String> actualLines = IOUtils.readLines(new StringReader(message.getContent()));
+    assertEquals(1, actualLines.size());
+    // All data is filtered out.
+    assertEquals("key,value", actualLines.get(0));
+  }
+
 }


### PR DESCRIPTION
## Motivation

Because of https://github.com/adaptris/interlok/pull/524 there is a new aggregate() method that works on Iterable rather than Collections (for lazy iteration with large messages / joins).

The CSV stuff should implement aggregate so that it can iterate over the list as required.

## Modification

- Directly implement aggregate() method that is now defined in MessageAggregator. 
- joinMessage() delegates to it
- Add support for filtering which was missing in the original implementation since it's down to the impl to figure that out.
- Add support for overwriting metadata which was missing in the original since it's down to the impl to figure that out.

## Result

No visible change for the user.

## Testing

Unit tests pass and any existing configuration should work.