### PR TITLE
INTERLOK-3555 Update the pom url to point to the right doc page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -282,8 +282,8 @@ publishing {
       pom.withXml {
         asNode().appendNode("description", "Handling CSV files using Interlok; transform to XML, splitting, JDBC utilities")
         asNode().appendNode("name", componentName)
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/cookbook/cookbook-csv-transform")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "http://interlok.adaptris.net/interlok-docs/cookbook-csv-transform.html")
         properties.appendNode("target", "3.8.0+")
         properties.appendNode("tags", "csv,transform,jdbc")
         properties.appendNode("license", "false")


### PR DESCRIPTION
## Motivation

The documentation was broken since we changed the doc site

## Modification

Fix the doc url

## Result

The pom has a correct doc url

## Testing

Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.
