### PR TITLE
Add exclusion for gfc-semver

### DIFF
--- a/interlok-csv-schema/build.gradle
+++ b/interlok-csv-schema/build.gradle
@@ -19,7 +19,9 @@ dependencies {
   implementation("org.scala-lang.plugins:scala-continuations-library_2.11:1.0.3") {
     exclude(group: "org.scala-lang", module: "scala-library")
   }
-  api ("uk.gov.nationalarchives:csv-validator-java-api:1.1.5")
+  api ("uk.gov.nationalarchives:csv-validator-java-api:1.1.5") {
+    exclude (group: "com.gilt", module: "gfc-semver_2.11")
+  }
   // 0.1.0 has disappeared, used be in bintray that that's basically now defunct.
   // https://dl.bintray.com/giltgroupe/maven/com/gilt/gfc-semver_2.11/0.1.0/gfc-semver_2.11-0.1.0.jar -> 403 Forbidden.
   // This is fine since 1.2-RC3 actually uses 0.0.5


### PR DESCRIPTION
## Motivation

If you depend on interlok-csv-schema then you get this from gradle.

```
* What went wrong:
A problem occurred evaluating root project 'ps-collect-poc-interlok'.
> Could not create task ':verifyLauncherJar'.
   > Could not resolve all files for configuration ':interlokRuntime'.
      > Could not find com.gilt:gfc-semver_2.11:0.1.0.
        Searched in the following locations:
          - https://repo.maven.apache.org/maven2/com/gilt/gfc-semver_2.11/0.1.0/gfc-semver_2.11-0.1.0.pom
          - https://nexus.adaptris.net/nexus/content/groups/public/com/gilt/gfc-semver_2.11/0.1.0/gfc-semver_2.11-0.1.0.pom
          - https://nexus.adaptris.net/nexus/content/groups/interlok/com/gilt/gfc-semver_2.11/0.1.0/gfc-semver_2.11-0.1.0.pom
          - https://oss.sonatype.org/content/repositories/releases/com/gilt/gfc-semver_2.11/0.1.0/gfc-semver_2.11-0.1.0.pom
        Required by:
            project : > com.adaptris:interlok-csv-schema:4.4-SNAPSHOT:20211213.081906-6
      > Could not find com.gilt:gfc-semver_2.11:0.1.0.
        Searched in the following locations:
          - https://repo.maven.apache.org/maven2/com/gilt/gfc-semver_2.11/0.1.0/gfc-semver_2.11-0.1.0.pom
          - https://nexus.adaptris.net/nexus/content/groups/public/com/gilt/gfc-semver_2.11/0.1.0/gfc-semver_2.11-0.1.0.pom
          - https://nexus.adaptris.net/nexus/content/groups/interlok/com/gilt/gfc-semver_2.11/0.1.0/gfc-semver_2.11-0.1.0.pom
          - https://oss.sonatype.org/content/repositories/releases/com/gilt/gfc-semver_2.11/0.1.0/gfc-semver_2.11-0.1.0.pom
        Required by:
            project : > com.adaptris:interlok-csv-schema:4.4-SNAPSHOT:20211213.081906-6 > uk.gov.nationalarchives:csv-validator-java-api:1.1.5 > uk.gov.nationalarchives:csv-validator-core:1.1.5
```

gfc-semver 0.1.0 no longer exists because bintray is dead. validator-core 1.2RCx has already changed to on 0.0.5 

Gradle is breaking because it wants to resolve 0.1.0 and fails if it can't find it; so we need to exclude that artifact from the dependency tree and add the right version in.

## Modification

Since gfc-semver 0.1.0 is no longer available, add exclusion so that it doesn't attempt to try and find it. We have already pinned the version at 0.
If it's not excluded then depending on interlok-csv-schema will try to
resolve 0.1.0 which will fail even though it is pinned at 0.0.5 explicitly


## PR Checklist

- [x] been self-reviewed.

## Result

A working build.

## Testing

Instead of having to do
```
  // Work-around for https://github.com/adaptris/interlok-csv/pull/178
  interlokRuntime ("com.adaptris:interlok-csv-schema:$interlokVersion") {
    changing=true
    exclude (group: "com.gilt", module: "gfc-semver_2.11")
  }
  interlokRuntime("com.gilt:gfc-semver_2.11:0.0.5")
```
You can just do
```
  interlokRuntime ("com.adaptris:interlok-csv-schema:$interlokVersion") {    changing=true  }
```